### PR TITLE
json-ld cached doc loader

### DIFF
--- a/util/helpers_test.go
+++ b/util/helpers_test.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"testing"
+	"time"
 
+	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,5 +90,50 @@ func TestMergeUniqueValues(t *testing.T) {
 		b := []string{"c", "d", "e"}
 		res := MergeUniqueValues(a, b)
 		assert.True(tt, len(res) == len(a)+2)
+	})
+}
+
+func TestLDProcessor(t *testing.T) {
+	testJsonDLContextUrlStr := "http://schema.org/"
+	ldProcessor := NewLDProcessor()
+
+	t.Run("caching document loader", func(tt *testing.T) {
+		numOfLoads := 5
+		nonCachedLoader := ld.NewDefaultDocumentLoader(nil)
+		t0 := time.Now()
+		for i := 0; i < numOfLoads; i++ {
+			doc, err := nonCachedLoader.LoadDocument(testJsonDLContextUrlStr)
+			assert.NoError(tt, err)
+			assert.NotNil(tt, doc)
+		}
+		dtNonCached := time.Now().Sub(t0)
+		tt.Logf("non-cached document loader for %d tests dt: %v\n", numOfLoads, dtNonCached)
+
+		ldProcessor := NewLDProcessor()
+		t1 := time.Now()
+		for i := 0; i < numOfLoads; i++ {
+			doc, err := ldProcessor.DocumentLoader.LoadDocument(testJsonDLContextUrlStr)
+			assert.NoError(tt, err)
+			assert.NotNil(tt, doc)
+		}
+		dtCached := time.Now().Sub(t1)
+		tt.Logf("caching document loader for %d tests dt: %v\n", numOfLoads, dtCached)
+
+		assert.True(tt, dtNonCached/dtCached > 2.0)
+	})
+
+	t.Run("get context from map", func(tt *testing.T) {
+		contextMap := map[string]interface{}{
+			"dc": "http://purl.org/dc/elements/1.1/",
+			"ex": "http://example.org/vocab#",
+			"ex:contains": map[string]interface{}{
+				"@type": "@id",
+			},
+		}
+
+		activeCtx, err := ldProcessor.GetContextFromMap(contextMap)
+		//activeCtx: &{values:map[@base: processingMode:json-ld-1.1] options:0xc0001288f0 termDefinitions:map[dc:map[@id:http://purl.org/dc/elements/1.1/ @reverse:false _prefix:true] ex:map[@id:http://example.org/vocab# @reverse:false _prefix:true] ex:contains:map[@id:http://example.org/vocab#contains @reverse:false @type:@id]] inverse:map[] protected:map[] previousContext:<nil>}
+		assert.NoError(tt, err)
+		assert.NotNil(tt, activeCtx)
 	})
 }

--- a/util/helpers_test.go
+++ b/util/helpers_test.go
@@ -94,7 +94,7 @@ func TestMergeUniqueValues(t *testing.T) {
 }
 
 func TestLDProcessor(t *testing.T) {
-	testJsonDLContextUrlStr := "http://schema.org/"
+	testJSONDLContextURLStr := "http://schema.org/"
 	ldProcessor := NewLDProcessor()
 
 	t.Run("caching document loader", func(tt *testing.T) {
@@ -102,7 +102,7 @@ func TestLDProcessor(t *testing.T) {
 		nonCachedLoader := ld.NewDefaultDocumentLoader(nil)
 		t0 := time.Now()
 		for i := 0; i < numOfLoads; i++ {
-			doc, err := nonCachedLoader.LoadDocument(testJsonDLContextUrlStr)
+			doc, err := nonCachedLoader.LoadDocument(testJSONDLContextURLStr)
 			assert.NoError(tt, err)
 			assert.NotNil(tt, doc)
 		}
@@ -112,7 +112,7 @@ func TestLDProcessor(t *testing.T) {
 		ldProcessor := NewLDProcessor()
 		t1 := time.Now()
 		for i := 0; i < numOfLoads; i++ {
-			doc, err := ldProcessor.DocumentLoader.LoadDocument(testJsonDLContextUrlStr)
+			doc, err := ldProcessor.DocumentLoader.LoadDocument(testJSONDLContextURLStr)
 			assert.NoError(tt, err)
 			assert.NotNil(tt, doc)
 		}
@@ -132,7 +132,7 @@ func TestLDProcessor(t *testing.T) {
 		}
 
 		activeCtx, err := ldProcessor.GetContextFromMap(contextMap)
-		//activeCtx: &{values:map[@base: processingMode:json-ld-1.1] options:0xc0001288f0 termDefinitions:map[dc:map[@id:http://purl.org/dc/elements/1.1/ @reverse:false _prefix:true] ex:map[@id:http://example.org/vocab# @reverse:false _prefix:true] ex:contains:map[@id:http://example.org/vocab#contains @reverse:false @type:@id]] inverse:map[] protected:map[] previousContext:<nil>}
+		//expected activeCtx output is &{values:map[@base: processingMode:json-ld-1.1] options:0xc0001288f0 termDefinitions:map[dc:map[@id:http://purl.org/dc/elements/1.1/ @reverse:false _prefix:true] ex:map[@id:http://example.org/vocab# @reverse:false _prefix:true] ex:contains:map[@id:http://example.org/vocab#contains @reverse:false @type:@id]] inverse:map[] protected:map[] previousContext:<nil>}
 		assert.NoError(tt, err)
 		assert.NotNil(tt, activeCtx)
 	})


### PR DESCRIPTION
[json-gold](https://github.com/piprate/json-gold) does have the caching document loader implemented (RFC7324)
It is enabled by passing the caching loader into the ldProcessor options
Added it as the default option [here](https://github.com/singyiu/ssi-sdk/blob/c1f4324e9d365481dde54b47af76be47e0f82b67/util/helpers.go#L44).

Json-ld context can be loaded as a json-ld document (type map[string]interface{}) using the loadDocument function [test example](https://github.com/singyiu/ssi-sdk/blob/c1f4324e9d365481dde54b47af76be47e0f82b67/util/helpers_test.go#L115)
or further converting it into a json-gold.Context object [test example](https://github.com/singyiu/ssi-sdk/blob/c1f4324e9d365481dde54b47af76be47e0f82b67/util/helpers_test.go#L134)
A helper function "GetContextFromMap" was added.