### PR TITLE
remove casting from status list check

### DIFF
--- a/credential/status/statuslist2021.go
+++ b/credential/status/statuslist2021.go
@@ -115,8 +115,8 @@ func prepareCredentialsForStatusList(purpose StatusPurpose, credentials []creden
 	var errorResults []string
 
 	for _, cred := range credentials {
-		entry, ok := cred.CredentialStatus.(StatusList2021Entry)
-		if !ok {
+		entry, err := getStatusEntry(cred.CredentialStatus)
+		if err != nil {
 			errorResults = append(errorResults, fmt.Sprintf("credential<%s> not using the StatusList2021 "+
 				"credentialStatus property", cred.ID))
 		} else {
@@ -145,6 +145,19 @@ func prepareCredentialsForStatusList(purpose StatusPurpose, credentials []creden
 		return nil, fmt.Errorf("%d credential(s) in error: %s", numFailed, strings.Join(errorResults, ","))
 	}
 	return statusListIndices, nil
+}
+
+// determine whether the credential status property is of the expected format
+func getStatusEntry(maybeCredentialStatus interface{}) (*StatusList2021Entry, error) {
+	statusBytes, err := json.Marshal(maybeCredentialStatus)
+	if err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not marshal credential status property")
+	}
+	var statusEntry StatusList2021Entry
+	if err := json.Unmarshal(statusBytes, &statusEntry); err != nil {
+		return nil, util.LoggingErrorMsg(err, "could not unmarshal credential status property")
+	}
+	return &statusEntry, nil
 }
 
 // https://w3c-ccg.github.io/vc-status-list-2021/#bitstring-generation-algorithm

--- a/credential/status/statuslist2021.go
+++ b/credential/status/statuslist2021.go
@@ -148,6 +148,7 @@ func prepareCredentialsForStatusList(purpose StatusPurpose, credentials []creden
 }
 
 // determine whether the credential status property is of the expected format
+// additionally makes sure the status list has all required properties
 func getStatusEntry(maybeCredentialStatus interface{}) (*StatusList2021Entry, error) {
 	statusBytes, err := json.Marshal(maybeCredentialStatus)
 	if err != nil {
@@ -157,7 +158,7 @@ func getStatusEntry(maybeCredentialStatus interface{}) (*StatusList2021Entry, er
 	if err := json.Unmarshal(statusBytes, &statusEntry); err != nil {
 		return nil, util.LoggingErrorMsg(err, "could not unmarshal credential status property")
 	}
-	return &statusEntry, nil
+	return &statusEntry, util.IsValidStruct(statusEntry)
 }
 
 // https://w3c-ccg.github.io/vc-status-list-2021/#bitstring-generation-algorithm

--- a/credential/status/statuslist2021_test.go
+++ b/credential/status/statuslist2021_test.go
@@ -229,6 +229,7 @@ func TestGenerateStatusList2021Credential(t *testing.T) {
 				ID:                   revocationID,
 				Type:                 StatusList2021EntryType,
 				StatusPurpose:        StatusRevocation,
+				StatusListIndex:      "-1",
 				StatusListCredential: "test-cred",
 			},
 		}


### PR DESCRIPTION
the status list check was failing, due to the `CredentialStatus` property being an interface type. Type information can be lost, making the cast fail. Marshaling and unmarshaling into the object, and using the go struct validator is a safer way to do the check.