### PR TITLE
fix: remove build tags

### DIFF
--- a/credential/signing/jwt.go
+++ b/credential/signing/jwt.go
@@ -1,5 +1,3 @@
-//go:build jwx_es256k
-
 package signing
 
 import (

--- a/cryptosuite/jwt.go
+++ b/cryptosuite/jwt.go
@@ -1,5 +1,3 @@
-//go:build jwx_es256k
-
 package cryptosuite
 
 import (


### PR DESCRIPTION
related to https://github.com/lestrrat-go/jwx/issues/670 "You don't need to add build tags to your source code.". 