### PR TITLE
examples/did: Fix typo

### DIFF
--- a/examples/did/did.go
+++ b/examples/did/did.go
@@ -29,7 +29,7 @@ func main() {
 	handleError(err, "failed to generate key")
 
 	// Expand the DID into a DID Document
-	// Expanding is how did:key is reolved in the sdk
+	// Expanding is how did:key is resolved in the sdk
 	// https://www.w3.org/TR/did-core/#did-document-properties
 	didDoc, err := didKey.Expand()
 	handleError(err, "failed to expand did:key")


### PR DESCRIPTION
This PR fixes a typo in `examples/did`