### PR TITLE
remove print and json marshalling in builder at exchange layer

### DIFF
--- a/credential/exchange/builder.go
+++ b/credential/exchange/builder.go
@@ -4,7 +4,6 @@ import (
     "fmt"
     "reflect"
 
-    "github.com/goccy/go-json"
     "github.com/google/uuid"
     "github.com/pkg/errors"
 
@@ -31,9 +30,6 @@ func (pdb *PresentationDefinitionBuilder) Build() (*PresentationDefinition, erro
     if pdb.IsEmpty() {
         return nil, errors.New(BuilderEmptyError)
     }
-
-    b, _ := json.Marshal(pdb)
-    println(string(b))
 
     if err := pdb.PresentationDefinition.IsValid(); err != nil {
         return nil, util.LoggingErrorMsg(err, "presentation definition not ready to be built")


### PR DESCRIPTION
removes the print statement and marshaling in the builder on the exchange layer. There is no good reason to force a print here i think.