### PR TITLE
Enable golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,46 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.2
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.50
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,330 @@
+# See https://golangci-lint.run/usage/configuration/ for reference.
+run:
+  concurrency: 16
+  skip-dirs:
+    - bin
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - revive
+    - gosec
+    - govet
+    - staticcheck
+
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      - name: add-constant
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
+      - name: argument-limit
+        severity: warning
+        disabled: false
+        arguments: [ 4 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
+      - name: atomic
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
+      - name: banned-characters
+        severity: warning
+        disabled: false
+        arguments: [ "Ω", "Σ", "σ"]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
+      - name: bare-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
+      - name: blank-imports
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      - name: bool-literal-in-expr
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
+      - name: call-to-gc
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
+      - name: cognitive-complexity
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
+      - name: confusing-naming
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
+      - name: confusing-results
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
+      - name: constant-logical-expr
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+      - name: context-as-argument
+        severity: warning
+        disabled: false
+        arguments:
+          - allowTypesBefore: "*testing.T,*github.com/user/repo/testing.Harness"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
+      - name: context-keys-type
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
+      - name: cyclomatic
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
+      - name: datarace
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
+      - name: deep-exit
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      - name: defer
+        severity: warning
+        disabled: false
+        arguments:
+          - [ "call-chain", "loop" ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      - name: dot-imports
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
+      - name: empty-block
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      - name: empty-lines
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      - name: error-naming
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      - name: error-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      - name: error-strings
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
+      - name: errorf
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+      - name: exported
+        severity: warning
+        disabled: false
+        arguments:
+          - "checkPrivateReceivers"
+          - "disableStutteringCheck"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-header
+      - name: file-header
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      - name: flag-parameter
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
+      - name: function-result-limit
+        severity: warning
+        disabled: false
+        arguments: [ 3 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
+      - name: function-length
+        severity: warning
+        disabled: true
+        arguments: [ 20, 0 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
+      - name: get-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
+      - name: identical-branches
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      - name: if-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
+      - name: increment-decrement
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+      - name: indent-error-flow
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blacklist
+      - name: imports-blacklist
+        severity: warning
+        disabled: false
+        arguments:
+          - "crypto/md5"
+          - "crypto/sha1"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
+      - name: line-length-limit
+        severity: warning
+        disabled: true
+        arguments: [ 120 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
+      - name: max-public-structs
+        severity: warning
+        disabled: true
+        arguments: [ 3 ]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
+      - name: modifies-parameter
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
+      - name: modifies-value-receiver
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
+      - name: nested-structs
+        severity: warning
+        disabled: true
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
+      - name: optimize-operands-order
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      - name: package-comments
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
+      - name: range
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
+      - name: range-val-in-closure
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      - name: range-val-address
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
+      - name: receiver-naming
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      - name: redefines-builtin-id
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
+      - name: string-of-int
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      - name: string-format
+        severity: warning
+        disabled: false
+        arguments:
+          - - 'core.WriteError[1].Message'
+            - '/^([^A-Z]|$)/'
+            - must not start with a capital letter
+          - - 'fmt.Errorf[0]'
+            - '/(^|[^\.!?])$/'
+            - must not end in punctuation
+          - - panic
+            - '/^[^\n]*$/'
+            - must not contain line breaks
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+      - name: superfluous-else
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      - name: time-equal
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
+      - name: time-naming
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      - name: var-naming
+        severity: warning
+        disabled: false
+        arguments:
+          - [ "ID" ] # AllowList
+          - [ "VM" ] # DenyList
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
+      - name: var-declaration
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
+      - name: unconditional-recursion
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
+      - name: unexported-naming
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      - name: unexported-return
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      - name: unhandled-error
+        severity: warning
+        disabled: false
+        arguments:
+          - "fmt.Printf"
+          - "myFunction"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
+      - name: unnecessary-stmt
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
+      - name: unreachable-code
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      - name: waitgroup-by-value
+        severity: warning
+        disabled: false
+  gosec:
+    config:
+      G101:
+        pattern: "(/i)passwd|pass|password|pwd|secret|token|pw|apiKey|bearer"
+
+

--- a/credential/exchange/builder_test.go
+++ b/credential/exchange/builder_test.go
@@ -199,11 +199,9 @@ func TestInputDescriptorBuilderRequired(t *testing.T) {
 	definition, err := builder.Build()
 	assert.NotEmpty(t, definition)
 	assert.NoError(t, err)
-
 }
 
 func TestInputDescriptorBuilder(t *testing.T) {
-
 	builder := NewInputDescriptorBuilder()
 	_, err := builder.Build()
 

--- a/credential/exchange/model.go
+++ b/credential/exchange/model.go
@@ -186,7 +186,7 @@ func (cf *ClaimFormat) FormatValues() []string {
 
 // AlgOrProofTypePerFormat for a given format, return the supported alg or proof types. A nil response indicates
 // that the format is not supported.
-func (cf *ClaimFormat) AlgOrProofTypePerFormat(format string) []string {
+func (cf *ClaimFormat) AlgOrProofTypePerFormat(_ string) []string {
 	var res []string
 	if cf.JWT != nil {
 		for _, a := range cf.JWT.Alg {

--- a/credential/exchange/submission.go
+++ b/credential/exchange/submission.go
@@ -461,16 +461,15 @@ func normalizeJSONPath(path string) string {
 // processInputDescriptorField applies all possible path values to a claim, and checks to see if any match.
 // if a path matches fulfilled will be set to true and no processed value will be returned. if limitDisclosure is
 // set to true, the processed value will be returned as well.
-func processInputDescriptorField(field Field, claimData map[string]interface{}) (limited *limitedInputDescriptor, fulfilled bool) {
+func processInputDescriptorField(field Field, claimData map[string]interface{}) (*limitedInputDescriptor, bool) {
 	for _, path := range field.Path {
 		pathedData, err := jsonpath.JsonPathLookup(claimData, path)
 		if err == nil {
-			limited = &limitedInputDescriptor{
+			limited := &limitedInputDescriptor{
 				Path: path,
 				Data: pathedData,
 			}
-			fulfilled = true
-			return
+			return limited, true
 		}
 	}
 	if field.Optional {

--- a/credential/manifest/validation_test.go
+++ b/credential/manifest/validation_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestIsValidCredentialApplicationForManifest(t *testing.T) {
-
 	t.Run("Credential Application and Credential Manifest Pair Valid", func(tt *testing.T) {
 		cm, ca := getValidTestCredManifestCredApplication(tt)
 

--- a/credential/schema/vcjsonschema.go
+++ b/credential/schema/vcjsonschema.go
@@ -56,12 +56,12 @@ func IsValidCredentialSchema(maybeCredentialSchema string) error {
 	return nil
 }
 
-func IsCredentialValidForVCJSONSchema(credential credential.VerifiableCredential, vcJSONSchema VCJSONSchema) error {
+func IsCredentialValidForVCJSONSchema(cred credential.VerifiableCredential, vcJSONSchema VCJSONSchema) error {
 	schemaBytes, err := json.Marshal(vcJSONSchema.Schema)
 	if err != nil {
 		return err
 	}
-	return IsCredentialValidForSchema(credential, string(schemaBytes))
+	return IsCredentialValidForSchema(cred, string(schemaBytes))
 }
 
 // IsCredentialValidForSchema determines whether a given Verifiable Credential is valid against

--- a/credential/signing/jwt.go
+++ b/credential/signing/jwt.go
@@ -53,7 +53,6 @@ func SignVerifiableCredentialJWT(signer crypto.JWTSigner, cred credential.Verifi
 	} else {
 		logrus.WithError(err).Error("could not convert iat to unix time; setting to present moment")
 		issuanceDate = strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
-
 	}
 
 	if err := t.Set(jwt.NotBeforeKey, issuanceDate); err != nil {

--- a/credential/status/statuslist2021.go
+++ b/credential/status/statuslist2021.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
 	"github.com/bits-and-blooms/bitset"
-	"github.com/goccy/go-json"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -228,7 +228,7 @@ func bitstringExpansion(compressedBitstring string) ([]string, error) {
 		return nil, errors.Wrap(err, "could not unzip status list bitstring using GZIP")
 	}
 
-	unzipped, err := ioutil.ReadAll(zr)
+	unzipped, err := io.ReadAll(zr)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not expand status list bitstring using GZIP")
 	}

--- a/credential/verification/verification.go
+++ b/credential/verification/verification.go
@@ -38,7 +38,7 @@ func GetVerificationOption(opts []VerificationOption, id OptionKey) (interface{}
 	return nil, errors.Errorf("option with id <%s> not found", id)
 }
 
-type Verify func(credential credential.VerifiableCredential, opts ...VerificationOption) error
+type Verify func(cred credential.VerifiableCredential, opts ...VerificationOption) error
 
 // NewCredentialVerifier creates a new credential verifier which executes in the order of the verifiers provided
 func NewCredentialVerifier(verifiers []Verifier) (*CredentialVerifier, error) {

--- a/credential/verification/verification_test.go
+++ b/credential/verification/verification_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestVerifier(t *testing.T) {
-
 	t.Run("Test Basic Verifier", func(tt *testing.T) {
 		// empty verifier
 		_, err := NewCredentialVerifier(nil)
@@ -97,10 +96,9 @@ func TestVerifier(t *testing.T) {
 		err = verifier.VerifyCredential(sampleCredential, WithSchema(knownSchema))
 		assert.NoError(tt, err)
 	})
-
 }
 
-func NoOpVerifier(credential credential.VerifiableCredential, _ ...VerificationOption) error {
+func NoOpVerifier(_ credential.VerifiableCredential, _ ...VerificationOption) error {
 	return nil
 }
 

--- a/credential/verification/verifiers.go
+++ b/credential/verification/verifiers.go
@@ -36,13 +36,13 @@ func VerifyValidCredential(cred credential.VerifiableCredential, _ ...Verificati
 
 // VerifyExpiry verifies a credential's expiry date is not in the past. We assume the date is parseable as
 // an RFC3339 date time value.
-func VerifyExpiry(verifiableCred credential.VerifiableCredential, _ ...VerificationOption) error {
-	if verifiableCred.ExpirationDate == "" {
+func VerifyExpiry(cred credential.VerifiableCredential, _ ...VerificationOption) error {
+	if cred.ExpirationDate == "" {
 		return nil
 	}
-	expiryTime, err := time.Parse(time.RFC3339, verifiableCred.ExpirationDate)
+	expiryTime, err := time.Parse(time.RFC3339, cred.ExpirationDate)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse expiry date: %s", verifiableCred.ExpirationDate)
+		return errors.Wrapf(err, "failed to parse expiry date: %s", cred.ExpirationDate)
 	}
 	if expiryTime.Before(time.Now()) {
 		return fmt.Errorf("credential has expired as of %s", expiryTime.String())

--- a/crypto/jwk_test.go
+++ b/crypto/jwk_test.go
@@ -14,12 +14,12 @@ func TestJWKToPrivateKeyJWK(t *testing.T) {
 	assert.NotEmpty(t, privateKey)
 
 	// convert to JWK
-	jwkKey, err := jwk.New(privateKey)
+	key, err := jwk.New(privateKey)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, jwkKey)
+	assert.NotEmpty(t, key)
 
 	// to our representation of a jwk
-	privKeyJWK, err := JWKToPrivateKeyJWK(jwkKey)
+	privKeyJWK, err := JWKToPrivateKeyJWK(key)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, privKeyJWK)
 

--- a/crypto/jwk_test.go
+++ b/crypto/jwk_test.go
@@ -14,12 +14,12 @@ func TestJWKToPrivateKeyJWK(t *testing.T) {
 	assert.NotEmpty(t, privateKey)
 
 	// convert to JWK
-	jwk, err := jwk.New(privateKey)
+	jwkKey, err := jwk.New(privateKey)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, jwk)
+	assert.NotEmpty(t, jwkKey)
 
 	// to our representation of a jwk
-	privKeyJWK, err := JWKToPrivateKeyJWK(jwk)
+	privKeyJWK, err := JWKToPrivateKeyJWK(jwkKey)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, privKeyJWK)
 
@@ -34,12 +34,12 @@ func TestJWKToPublicKeyJWK(t *testing.T) {
 	assert.NotEmpty(t, publicKey)
 
 	// convert to JWK
-	jwk, err := jwk.New(publicKey)
+	key, err := jwk.New(publicKey)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, jwk)
+	assert.NotEmpty(t, key)
 
 	// to our representation of a jwk
-	pubKeyJWK, err := JWKToPublicKeyJWK(jwk)
+	pubKeyJWK, err := JWKToPublicKeyJWK(key)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, pubKeyJWK)
 

--- a/crypto/jwt.go
+++ b/crypto/jwt.go
@@ -118,7 +118,7 @@ func (sv *JWTSigner) SignJWT(kvs map[string]interface{}) ([]byte, error) {
 }
 
 // ParseJWT attempts to turn a string into a jwt.Token
-func (sv *JWTSigner) ParseJWT(token string) (jwt.Token, error) {
+func (*JWTSigner) ParseJWT(token string) (jwt.Token, error) {
 	parsed, err := jwt.Parse([]byte(token))
 	if err != nil {
 		logrus.WithError(err).Error("could not parse JWT")
@@ -137,7 +137,7 @@ func (sv *JWTVerifier) VerifyJWT(token string) error {
 }
 
 // ParseJWT attempts to turn a string into a jwt.Token
-func (sv *JWTVerifier) ParseJWT(token string) (jwt.Token, error) {
+func (*JWTVerifier) ParseJWT(token string) (jwt.Token, error) {
 	parsed, err := jwt.Parse([]byte(token))
 	if err != nil {
 		logrus.WithError(err).Error("could not parse JWT")
@@ -156,8 +156,8 @@ func (sv *JWTVerifier) VerifyAndParseJWT(token string) (jwt.Token, error) {
 	return parsed, nil
 }
 
-func GetCRVFromJWK(jwk jwk.Key) (string, error) {
-	maybeCrv, hasCrv := jwk.Get("crv")
+func GetCRVFromJWK(key jwk.Key) (string, error) {
+	maybeCrv, hasCrv := key.Get("crv")
 	if hasCrv {
 		crv, crvStr := maybeCrv.(jwa.EllipticCurveAlgorithm)
 		if !crvStr {

--- a/cryptosuite/jsonwebkey2020.go
+++ b/cryptosuite/jsonwebkey2020.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	JSONWebKey2020Name LDKeyType = "JsonWebKey2020"
+	JSONWebKey2020Type LDKeyType = "JsonWebKey2020"
 
 	// Supported key types
 
@@ -101,7 +101,7 @@ func JSONWebKey2020FromPrivateKey(key gocrypto.PrivateKey) (*JSONWebKey2020, err
 		return nil, err
 	}
 	return &JSONWebKey2020{
-		Type:          JSONWebKey2020Name,
+		Type:          JSONWebKey2020Type,
 		PrivateKeyJWK: *privKeyJWK,
 		PublicKeyJWK:  *pubKeyJWK,
 	}, nil
@@ -279,7 +279,7 @@ func NewJSONWebKeyVerifier(kid string, key crypto.PublicKeyJWK) (*JSONWebKeyVeri
 func PubKeyBytesToTypedKey(keyBytes []byte, kt LDKeyType) (gocrypto.PublicKey, error) {
 	var convertedKeyType crypto.KeyType
 	switch kt.String() {
-	case JSONWebKey2020Name.String():
+	case JSONWebKey2020Type.String():
 		// we cannot know this key type based on the bytes alone
 		return keyBytes, nil
 	case crypto.Ed25519.String(), Ed25519VerificationKey2018.String(), Ed25519VerificationKey2020.String():

--- a/cryptosuite/jsonwebkey2020.go
+++ b/cryptosuite/jsonwebkey2020.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	JsonWebKey2020 LDKeyType = "JsonWebKey2020"
+	JSONWebKey2020Name LDKeyType = "JsonWebKey2020"
 
 	// Supported key types
 
@@ -77,7 +77,6 @@ func GenerateJSONWebKey2020(kty KTY, crv CRV) (*JSONWebKey2020, error) {
 		default:
 			return nil, fmt.Errorf("unsupported OKP curve: %s", crv)
 		}
-
 	}
 	if kty == EC {
 		switch crv {
@@ -102,7 +101,7 @@ func JSONWebKey2020FromPrivateKey(key gocrypto.PrivateKey) (*JSONWebKey2020, err
 		return nil, err
 	}
 	return &JSONWebKey2020{
-		Type:          JsonWebKey2020,
+		Type:          JSONWebKey2020Name,
 		PrivateKeyJWK: *privKeyJWK,
 		PublicKeyJWK:  *pubKeyJWK,
 	}, nil
@@ -205,7 +204,7 @@ func (s *JSONWebKeySigner) GetKeyType() string {
 	return string(s.Key.KeyType())
 }
 
-func (s *JSONWebKeySigner) GetSignatureType() SignatureType {
+func (*JSONWebKeySigner) GetSignatureType() SignatureType {
 	return JSONWebSignature2020
 }
 
@@ -280,7 +279,7 @@ func NewJSONWebKeyVerifier(kid string, key crypto.PublicKeyJWK) (*JSONWebKeyVeri
 func PubKeyBytesToTypedKey(keyBytes []byte, kt LDKeyType) (gocrypto.PublicKey, error) {
 	var convertedKeyType crypto.KeyType
 	switch kt.String() {
-	case JsonWebKey2020.String():
+	case JSONWebKey2020Name.String():
 		// we cannot know this key type based on the bytes alone
 		return keyBytes, nil
 	case crypto.Ed25519.String(), Ed25519VerificationKey2018.String(), Ed25519VerificationKey2020.String():

--- a/cryptosuite/jwssignaturesuite.go
+++ b/cryptosuite/jwssignaturesuite.go
@@ -22,7 +22,7 @@ const (
 	JSONWebSignature2020Context                string        = "https://w3id.org/security/suites/jws-2020/v1"
 	JSONWebSignature2020                       SignatureType = "JsonWebSignature2020"
 	JWSSignatureSuiteID                        string        = "https://w3c-ccg.github.io/security-vocab/#JsonWebSignature2020"
-	JWSSignatureSuiteType                      LDKeyType     = JsonWebKey2020
+	JWSSignatureSuiteType                      LDKeyType     = JSONWebKey2020Name
 	JWSSignatureSuiteCanonicalizationAlgorithm string        = "https://w3id.org/security#URDNA2015"
 	// JWSSignatureSuiteDigestAlgorithm uses https://www.rfc-editor.org/rfc/rfc4634
 	JWSSignatureSuiteDigestAlgorithm gocrypto.Hash = gocrypto.SHA256
@@ -40,27 +40,27 @@ func GetJSONWebSignature2020Suite() CryptoSuite {
 
 // CryptoSuiteInfo interface
 
-func (j JWSSignatureSuite) ID() string {
+func (JWSSignatureSuite) ID() string {
 	return JWSSignatureSuiteID
 }
 
-func (j JWSSignatureSuite) Type() LDKeyType {
+func (JWSSignatureSuite) Type() LDKeyType {
 	return JWSSignatureSuiteType
 }
 
-func (j JWSSignatureSuite) CanonicalizationAlgorithm() string {
+func (JWSSignatureSuite) CanonicalizationAlgorithm() string {
 	return JWSSignatureSuiteCanonicalizationAlgorithm
 }
 
-func (j JWSSignatureSuite) MessageDigestAlgorithm() gocrypto.Hash {
+func (JWSSignatureSuite) MessageDigestAlgorithm() gocrypto.Hash {
 	return JWSSignatureSuiteDigestAlgorithm
 }
 
-func (j JWSSignatureSuite) SignatureAlgorithm() SignatureType {
+func (JWSSignatureSuite) SignatureAlgorithm() SignatureType {
 	return JWSSignatureSuiteProofAlgorithm
 }
 
-func (j JWSSignatureSuite) RequiredContexts() []string {
+func (JWSSignatureSuite) RequiredContexts() []string {
 	return []string{JSONWebSignature2020Context}
 }
 
@@ -148,7 +148,7 @@ func (j JWSSignatureSuite) Verify(v Verifier, p Provable) error {
 
 // CryptoSuiteProofType interface
 
-func (j JWSSignatureSuite) Marshal(data interface{}) ([]byte, error) {
+func (JWSSignatureSuite) Marshal(data interface{}) ([]byte, error) {
 	// JSONify the provable object
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
@@ -157,7 +157,7 @@ func (j JWSSignatureSuite) Marshal(data interface{}) ([]byte, error) {
 	return jsonBytes, nil
 }
 
-func (j JWSSignatureSuite) Canonicalize(marshaled []byte) (*string, error) {
+func (JWSSignatureSuite) Canonicalize(marshaled []byte) (*string, error) {
 	// the LD library anticipates a generic golang json object to normalize
 	var generic map[string]interface{}
 	if err := json.Unmarshal(marshaled, &generic); err != nil {
@@ -279,7 +279,7 @@ func (j JWSSignatureSuite) prepareProof(proof crypto.Proof, opts *ProofOptions) 
 	return &p, nil
 }
 
-type JsonWebSignature2020Proof struct {
+type JSONWebSignature2020Proof struct {
 	Type               SignatureType `json:"type,omitempty"`
 	Created            string        `json:"created,omitempty"`
 	JWS                string        `json:"jws,omitempty"`
@@ -288,7 +288,7 @@ type JsonWebSignature2020Proof struct {
 	VerificationMethod string        `json:"verificationMethod,omitempty"`
 }
 
-func FromGenericProof(p crypto.Proof) (*JsonWebSignature2020Proof, error) {
+func FromGenericProof(p crypto.Proof) (*JSONWebSignature2020Proof, error) {
 	proofBytes, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
@@ -321,7 +321,7 @@ func FromGenericProof(p crypto.Proof) (*JsonWebSignature2020Proof, error) {
 	if !ok {
 		methodValue = ""
 	}
-	return &JsonWebSignature2020Proof{
+	return &JSONWebSignature2020Proof{
 		Type:               SignatureType(typeValue),
 		Created:            createdValue,
 		JWS:                jwsValue,
@@ -331,24 +331,24 @@ func FromGenericProof(p crypto.Proof) (*JsonWebSignature2020Proof, error) {
 	}, nil
 }
 
-func (j *JsonWebSignature2020Proof) ToGenericProof() crypto.Proof {
+func (j *JSONWebSignature2020Proof) ToGenericProof() crypto.Proof {
 	return j
 }
 
-func (j *JsonWebSignature2020Proof) SetDetachedJWS(jws string) {
+func (j *JSONWebSignature2020Proof) SetDetachedJWS(jws string) {
 	if j != nil {
 		j.JWS = jws
 	}
 }
 
-func (j *JsonWebSignature2020Proof) GetDetachedJWS() string {
+func (j *JSONWebSignature2020Proof) GetDetachedJWS() string {
 	if j != nil {
 		return ""
 	}
 	return j.JWS
 }
 
-func (j *JsonWebSignature2020Proof) DecodeJWS() ([]byte, error) {
+func (j *JSONWebSignature2020Proof) DecodeJWS() ([]byte, error) {
 	if j == nil {
 		return nil, errors.New("cannot decode jws on empty proof")
 	}
@@ -359,12 +359,12 @@ func (j *JsonWebSignature2020Proof) DecodeJWS() ([]byte, error) {
 	return base64.RawURLEncoding.DecodeString(jwsParts[2])
 }
 
-func (j JWSSignatureSuite) createProof(verificationMethod string, purpose ProofPurpose) JsonWebSignature2020Proof {
+func (j JWSSignatureSuite) createProof(verificationMethod string, purpose ProofPurpose) JSONWebSignature2020Proof {
 	var challenge string
 	if purpose == Authentication {
 		challenge = uuid.NewString()
 	}
-	return JsonWebSignature2020Proof{
+	return JSONWebSignature2020Proof{
 		Type:               j.SignatureAlgorithm(),
 		Created:            GetRFC3339Timestamp(),
 		ProofPurpose:       purpose,

--- a/cryptosuite/jwssignaturesuite.go
+++ b/cryptosuite/jwssignaturesuite.go
@@ -22,7 +22,7 @@ const (
 	JSONWebSignature2020Context                string        = "https://w3id.org/security/suites/jws-2020/v1"
 	JSONWebSignature2020                       SignatureType = "JsonWebSignature2020"
 	JWSSignatureSuiteID                        string        = "https://w3c-ccg.github.io/security-vocab/#JsonWebSignature2020"
-	JWSSignatureSuiteType                      LDKeyType     = JSONWebKey2020Name
+	JWSSignatureSuiteType                      LDKeyType     = JSONWebKey2020Type
 	JWSSignatureSuiteCanonicalizationAlgorithm string        = "https://w3id.org/security#URDNA2015"
 	// JWSSignatureSuiteDigestAlgorithm uses https://www.rfc-editor.org/rfc/rfc4634
 	JWSSignatureSuiteDigestAlgorithm gocrypto.Hash = gocrypto.SHA256

--- a/cryptosuite/jwssignaturesuite_test.go
+++ b/cryptosuite/jwssignaturesuite_test.go
@@ -211,7 +211,7 @@ func TestCredentialLDProof(t *testing.T) {
 	assert.NotEmpty(t, knownCred.Proof)
 
 	// cast to known proof type
-	p, ok := (*knownCred.Proof).(JsonWebSignature2020Proof)
+	p, ok := (*knownCred.Proof).(JSONWebSignature2020Proof)
 	assert.True(t, ok)
 	assert.Equal(t, JSONWebSignature2020, p.Type)
 	assert.NotEmpty(t, p.JWS)
@@ -245,7 +245,7 @@ func TestJsonWebSignature2020TestVectorCredential0(t *testing.T) {
 	assert.NoError(t, err)
 
 	// https://github.com/decentralized-identity/JWS-Test-Suite/blob/main/data/implementations/transmute/credential-0--key-0-ed25519.vc.json
-	knownProof := JsonWebSignature2020Proof{
+	knownProof := JSONWebSignature2020Proof{
 		Type:               "JsonWebSignature2020",
 		Created:            "2022-01-24T23:26:38Z",
 		JWS:                "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..377mL0aIk_YL_scEZh1BIzje17vD4F7U8WPo2ufgkkGLwDNXHDhN99zpnsvsozD5Si82gRbDHqFu3Rp6dLH7Ag",

--- a/did/key.go
+++ b/did/key.go
@@ -161,7 +161,7 @@ func (d DIDKey) Decode() ([]byte, cryptosuite.LDKeyType, error) {
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Type, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:key: %d", multiCodecValue)
 		logrus.WithError(err).Error()
@@ -207,7 +207,7 @@ func (d DIDKey) Expand() (*DIDDocument, error) {
 }
 
 func constructVerificationMethod(id, keyReference string, pubKey []byte, keyType cryptosuite.LDKeyType) (*VerificationMethod, error) {
-	if keyType != cryptosuite.JSONWebKey2020Name {
+	if keyType != cryptosuite.JSONWebKey2020Type {
 		return &VerificationMethod{
 			ID:              keyReference,
 			Type:            keyType,

--- a/did/key.go
+++ b/did/key.go
@@ -49,7 +49,7 @@ func (d DIDKey) Suffix() (string, error) {
 	return split[1], nil
 }
 
-func (d DIDKey) Method() Method {
+func (DIDKey) Method() Method {
 	return KeyMethod
 }
 
@@ -161,7 +161,7 @@ func (d DIDKey) Decode() ([]byte, cryptosuite.LDKeyType, error) {
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JsonWebKey2020, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:key: %d", multiCodecValue)
 		logrus.WithError(err).Error()
@@ -207,7 +207,7 @@ func (d DIDKey) Expand() (*DIDDocument, error) {
 }
 
 func constructVerificationMethod(id, keyReference string, pubKey []byte, keyType cryptosuite.LDKeyType) (*VerificationMethod, error) {
-	if keyType != cryptosuite.JsonWebKey2020 {
+	if keyType != cryptosuite.JSONWebKey2020Name {
 		return &VerificationMethod{
 			ID:              keyReference,
 			Type:            keyType,
@@ -254,7 +254,7 @@ func GetSupportedDIDKeyTypes() []crypto.KeyType {
 
 type KeyResolver struct{}
 
-func (r KeyResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutionResult, error) {
+func (KeyResolver) Resolve(did string, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	if !strings.HasPrefix(did, DIDKeyPrefix) {
 		return nil, fmt.Errorf("not a did:key DID: %s", did)
 	}
@@ -267,6 +267,6 @@ func (r KeyResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolution
 	return &DIDResolutionResult{DIDDocument: *doc}, nil
 }
 
-func (r KeyResolver) Method() Method {
+func (KeyResolver) Method() Method {
 	return KeyMethod
 }

--- a/did/key_test.go
+++ b/did/key_test.go
@@ -402,7 +402,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
 		didKey2 := DIDKey(did2)
@@ -410,7 +410,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("P-384", func(tt *testing.T) {
@@ -420,7 +420,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:z82LkvCwHNreneWpsgPEbV3gu1C6NFJEBg4srfJ5gdxEsMGRJUz2sG9FE42shbn2xkZJh54"
 		didKey2 := DIDKey(did2)
@@ -428,7 +428,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("P-521", func(tt *testing.T) {
@@ -438,7 +438,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f"
 		didKey2 := DIDKey(did2)
@@ -446,7 +446,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("RSA 2048", func(tt *testing.T) {
@@ -456,6 +456,6 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Type, didDoc1.VerificationMethod[0].Type)
 	})
 }

--- a/did/key_test.go
+++ b/did/key_test.go
@@ -402,7 +402,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
 		didKey2 := DIDKey(did2)
@@ -410,7 +410,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("P-384", func(tt *testing.T) {
@@ -420,7 +420,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:z82LkvCwHNreneWpsgPEbV3gu1C6NFJEBg4srfJ5gdxEsMGRJUz2sG9FE42shbn2xkZJh54"
 		didKey2 := DIDKey(did2)
@@ -428,7 +428,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("P-521", func(tt *testing.T) {
@@ -438,7 +438,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
 
 		did2 := "did:key:z2J9gcGdb2nEyMDmzQYv2QZQcM1vXktvy1Pw4MduSWxGabLZ9XESSWLQgbuPhwnXN7zP7HpTzWqrMTzaY5zWe6hpzJ2jnw4f"
 		didKey2 := DIDKey(did2)
@@ -446,7 +446,7 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did2, didDoc2.ID)
 		assert.Equal(tt, 1, len(didDoc2.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc2.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc2.VerificationMethod[0].Type)
 	})
 
 	t.Run("RSA 2048", func(tt *testing.T) {
@@ -456,6 +456,6 @@ func TestKnownTestVectors(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, did1, didDoc1.ID)
 		assert.Equal(tt, 1, len(didDoc1.VerificationMethod))
-		assert.Equal(tt, cryptosuite.JsonWebKey2020, didDoc1.VerificationMethod[0].Type)
+		assert.Equal(tt, cryptosuite.JSONWebKey2020Name, didDoc1.VerificationMethod[0].Type)
 	})
 }

--- a/did/model.go
+++ b/did/model.go
@@ -141,7 +141,7 @@ func KeyTypeToLDKeyType(kt crypto.KeyType) (cryptosuite.LDKeyType, error) {
 	case crypto.SECP256k1:
 		return cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case crypto.P256, crypto.P384, crypto.P521, crypto.RSA:
-		return cryptosuite.JsonWebKey2020, nil
+		return cryptosuite.JSONWebKey2020Name, nil
 	default:
 		err := fmt.Errorf("unsupported keyType: %+v", kt)
 		errMsg := fmt.Sprintf("keyType %+v failed to convert to LDKeyType", kt)

--- a/did/model.go
+++ b/did/model.go
@@ -141,7 +141,7 @@ func KeyTypeToLDKeyType(kt crypto.KeyType) (cryptosuite.LDKeyType, error) {
 	case crypto.SECP256k1:
 		return cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case crypto.P256, crypto.P384, crypto.P521, crypto.RSA:
-		return cryptosuite.JSONWebKey2020Name, nil
+		return cryptosuite.JSONWebKey2020Type, nil
 	default:
 		err := fmt.Errorf("unsupported keyType: %+v", kt)
 		errMsg := fmt.Sprintf("keyType %+v failed to convert to LDKeyType", kt)

--- a/did/model_test.go
+++ b/did/model_test.go
@@ -97,7 +97,7 @@ func TestKeyTypeToLDKeyType(t *testing.T) {
 
 	kt, err = KeyTypeToLDKeyType(crypto.P256)
 	assert.NoError(t, err)
-	assert.Equal(t, kt, cryptosuite.JSONWebKey2020Name)
+	assert.Equal(t, kt, cryptosuite.JSONWebKey2020Type)
 
 	_, err = KeyTypeToLDKeyType(crypto.KeyType("bad"))
 	assert.Error(t, err)

--- a/did/model_test.go
+++ b/did/model_test.go
@@ -2,12 +2,12 @@ package did
 
 import (
 	"embed"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/cryptosuite"
-	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -97,9 +97,9 @@ func TestKeyTypeToLDKeyType(t *testing.T) {
 
 	kt, err = KeyTypeToLDKeyType(crypto.P256)
 	assert.NoError(t, err)
-	assert.Equal(t, kt, cryptosuite.JsonWebKey2020)
+	assert.Equal(t, kt, cryptosuite.JSONWebKey2020Name)
 
-	kt, err = KeyTypeToLDKeyType(crypto.KeyType("bad"))
+	_, err = KeyTypeToLDKeyType(crypto.KeyType("bad"))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported keyType")
 }

--- a/did/peer.go
+++ b/did/peer.go
@@ -86,7 +86,7 @@ func (d DIDPeer) Suffix() (string, error) {
 	return s[index:], nil
 }
 
-func (d DIDPeer) Method() Method {
+func (DIDPeer) Method() Method {
 	return PeerMethod
 }
 
@@ -99,7 +99,7 @@ type PeerMethod0 struct {
 	kt crypto.KeyType
 }
 
-func (m PeerMethod0) Method() Method {
+func (PeerMethod0) Method() Method {
 	return PeerMethod
 }
 
@@ -119,7 +119,7 @@ type PeerDelta struct {
 	When   int64     `json:"when"`   // <ISO8601/RFC3339 UTC timestamp with at least second precision>
 }
 
-func (d DIDPeer) Delta(b DIDPeer) (*PeerDelta, error) {
+func (DIDPeer) Delta(_ DIDPeer) (*PeerDelta, error) {
 	return nil, errors.Wrap(util.NotImplementedError, "peer:did delta")
 }
 
@@ -127,7 +127,7 @@ func (d DIDPeer) Delta(b DIDPeer) (*PeerDelta, error) {
 // https://identity.foundation/peer-did-method-spec/#crdts
 
 // Generates the key by types
-func (d DIDPeer) generateKeyByType(kt crypto.KeyType) (gocrypto.PublicKey, gocrypto.PrivateKey, error) {
+func (DIDPeer) generateKeyByType(kt crypto.KeyType) (gocrypto.PublicKey, gocrypto.PrivateKey, error) {
 	if !isSupportedKeyType(kt) {
 		err := fmt.Errorf("%s : %s for did:peer", util.UnsupportedError, kt)
 		return nil, nil, err
@@ -135,7 +135,7 @@ func (d DIDPeer) generateKeyByType(kt crypto.KeyType) (gocrypto.PublicKey, gocry
 	return crypto.GenerateKeyByKeyType(kt)
 }
 
-func (m PeerMethod0) Generate(kt crypto.KeyType, publicKey gocrypto.PublicKey) (*DIDPeer, error) {
+func (PeerMethod0) Generate(kt crypto.KeyType, publicKey gocrypto.PublicKey) (*DIDPeer, error) {
 	var did DIDPeer
 	encoded, err := encodePublicKeyWithKeyMultiCodecType(kt, publicKey)
 	if err != nil {
@@ -148,7 +148,7 @@ func (m PeerMethod0) Generate(kt crypto.KeyType, publicKey gocrypto.PublicKey) (
 // PeerMethod1 Method 1: genesis doc
 type PeerMethod1 struct{}
 
-func (m PeerMethod1) Method() Method {
+func (PeerMethod1) Method() Method {
 	return PeerMethod
 }
 
@@ -158,7 +158,7 @@ type PeerMethod2 struct {
 	Values []interface{}
 }
 
-func (m PeerMethod2) Method() Method {
+func (PeerMethod2) Method() Method {
 	return PeerMethod
 }
 
@@ -182,7 +182,7 @@ var supportedDIDPeerPurposes = map[PurposeType]bool{
 	PeerPurposeCapabilityServiceCode:    true,
 }
 
-func (d DIDPeer) IsValidPurpose(p PurposeType) bool {
+func (DIDPeer) IsValidPurpose(p PurposeType) bool {
 	if _, ok := supportedDIDPeerPurposes[p]; ok {
 		return true
 	}
@@ -192,8 +192,7 @@ func (d DIDPeer) IsValidPurpose(p PurposeType) bool {
 // Resolve resolves a did:peer into a DID Document
 // To do so, it decodes the key, constructs a verification  method, and returns a DID Document .This allows PeerMethod0
 // to implement the DID Resolution interface and be used to expand the did into the DID Document.
-func (m PeerMethod0) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
-
+func (PeerMethod0) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	d, ok := did.(DIDPeer)
 	if !ok {
 		return nil, errors.Wrap(util.CastingError, "did:peer")
@@ -233,14 +232,14 @@ func (m PeerMethod0) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult
 	return &DIDResolutionResult{DIDDocument: document}, nil
 }
 
-func (m PeerMethod1) resolve(d DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
+func (PeerMethod1) resolve(d DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	if _, ok := d.(DIDPeer); !ok {
 		return nil, errors.Wrap(util.CastingError, DIDPeerPrefix)
 	}
 	return nil, util.NotImplementedError
 }
 
-func (d DIDPeer) buildVerificationMethod(data, did string) (*VerificationMethod, error) {
+func (DIDPeer) buildVerificationMethod(data, did string) (*VerificationMethod, error) {
 	_, keyType, err := decodePublicKeyWithType([]byte(data))
 	if err != nil {
 		return nil, err
@@ -258,8 +257,7 @@ func (d DIDPeer) buildVerificationMethod(data, did string) (*VerificationMethod,
 // Resolve Splits the DID string into element.
 // Extract element purpose and decode each key or service.
 // Insert each key or service into the document according to the designated pu
-func (m PeerMethod2) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
-
+func (PeerMethod2) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	d, ok := did.(DIDPeer)
 	if !ok {
 		return nil, errors.Wrap(util.CastingError, "did:peer")
@@ -340,6 +338,7 @@ func (m PeerMethod2) resolve(did DID, _ ResolutionOptions) (*DIDResolutionResult
 // 5. Encode and append a service type to the end of the peer DID if desired as described below.
 func (m PeerMethod2) Generate() (*DIDPeer, error) {
 	if len(m.Values) == 0 {
+		// revive:disable-next-line:error-strings We do not want to change to error messages sent to clients.
 		return nil, errors.New("no keys specified for did:peer. could not build.")
 	}
 
@@ -402,7 +401,7 @@ type PeerServiceBlockEncoded struct {
 // Convert to string, and remove unnecessary whitespace, such as spaces and newlines.
 // Base64URL Encode String (no padding)
 // Prefix encoded service with a period character (.) and S
-func (d DIDPeer) encodeService(p Service) (string, error) {
+func (DIDPeer) encodeService(p Service) (string, error) {
 	if p.ServiceEndpoint == nil {
 		return "", errors.Wrap(util.UndefinedError, "service endpoint is not defined")
 	}
@@ -423,11 +422,10 @@ func (d DIDPeer) encodeService(p Service) (string, error) {
 		return "", err
 	}
 	return b64.RawURLEncoding.EncodeToString([]byte(string(dat))), nil
-
 }
 
 // Checks if the service block is valid
-func (d DIDPeer) checkValidPeerServiceBlock(s string) bool {
+func (DIDPeer) checkValidPeerServiceBlock(s string) bool {
 	if string(s[:2]) != "."+string(PeerPurposeCapabilityServiceCode) {
 		return false
 	}
@@ -437,7 +435,6 @@ func (d DIDPeer) checkValidPeerServiceBlock(s string) bool {
 // Decodes a service block.
 // Assumes that the service block has been stripped of any headers or identifiers.
 func (d DIDPeer) decodeServiceBlock(s string) (*Service, error) {
-
 	// check it starts with s.
 	if !d.checkValidPeerServiceBlock(s) {
 		return nil, errors.New("invalid string provided")
@@ -485,7 +482,7 @@ type ServiceTypeAbbreviationMap map[string]string
 // relative reference rather than an absolute value. For example, each controller property of a verificationMethod
 // that is owned by this DID would say "controller": "#id".). Calculate the SHA256 [RFC4634] hash of the bytes of
 // the stored variant of the genesis version of the DID doc, and make this value the new DID's numeric basis.
-func (m PeerMethod1) Generate() (*DIDPeer, error) {
+func (PeerMethod1) Generate() (*DIDPeer, error) {
 	// Create a Genesis Version
 	return nil, util.NotImplementedError
 }
@@ -516,8 +513,7 @@ func peerMethodAvailable(m string) bool {
 
 type PeerResolver struct{}
 
-func (r PeerResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutionResult, error) {
-
+func (PeerResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutionResult, error) {
 	if !strings.HasPrefix(did, DIDPeerPrefix) {
 		return nil, fmt.Errorf("not a did:peer DID: %s", did)
 	}
@@ -537,13 +533,13 @@ func (r PeerResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutio
 		case "2":
 			return PeerMethod2{}.resolve(didPeer, opts)
 		default:
-			return nil, errors.New(fmt.Sprintf("%s method not supported", m))
+			return nil, fmt.Errorf("%s method not supported", m)
 		}
 	}
 	// TODO(gabe) full resolution support to be added in https://github.com/TBD54566975/ssi-sdk/issues/38
 	return nil, fmt.Errorf("could not resolve peer DID: %s", did)
 }
 
-func (r PeerResolver) Method() Method {
+func (PeerResolver) Method() Method {
 	return PeerMethod
 }

--- a/did/peer_test.go
+++ b/did/peer_test.go
@@ -113,7 +113,6 @@ func TestDIDPeerUtilities(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.Equal(tt, res, s2)
 	})
-
 }
 
 func TestPeerResolver(t *testing.T) {
@@ -144,7 +143,6 @@ func TestPeerResolver(t *testing.T) {
 	m1 := "did:peer:1z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 	_, err = r.Resolve(m1, nil)
 	assert.Error(t, err)
-
 }
 
 func TestDIDPeerDeltaError(t *testing.T) {
@@ -293,7 +291,6 @@ func TestPeerResolveMethod0(t *testing.T) {
 // Encoded Service Endpoint: .SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=
 // Method 2 peer DID: did:peer:2.Ez6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH.VzXwpBnMdCm1cLmKuzgESn29nqnonp1ioqrQMRHNsmjMyppzx8xB2pv7cw8q1PdDacSrdWE3dtB9f7Nxk886mdzNFoPtY.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0=
 func TestPeerResolveMethod2(t *testing.T) {
-
 	testDoc := makeSamplePeerDIDDocument()
 	did := DIDPeer(testDoc.ID)
 
@@ -322,5 +319,4 @@ func TestPeerResolveMethod2(t *testing.T) {
 	assert.Equal(t, testDoc.Authentication[1].(VerificationMethod).Type, resolved.Authentication[1].(VerificationMethod).Type)
 	assert.Equal(t, testDoc.Authentication[1].(VerificationMethod).Controller, resolved.Authentication[1].(VerificationMethod).Controller)
 	assert.Equal(t, testDoc.Authentication[1].(VerificationMethod).PublicKeyMultibase, resolved.Authentication[1].(VerificationMethod).PublicKeyMultibase)
-
 }

--- a/did/pkh.go
+++ b/did/pkh.go
@@ -87,7 +87,7 @@ func (d DIDPKH) Suffix() (string, error) {
 	return split[1], nil
 }
 
-func (d DIDPKH) Method() Method {
+func (DIDPKH) Method() Method {
 	return PKHMethod
 }
 
@@ -246,7 +246,7 @@ func IsValidPKH(did DIDPKH) bool {
 
 type PKHResolver struct{}
 
-func (r PKHResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutionResult, error) {
+func (PKHResolver) Resolve(did string, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	if !strings.HasPrefix(did, DIDPKHPrefix) {
 		return nil, fmt.Errorf("not a did:pkh DID: %s", did)
 	}
@@ -259,6 +259,6 @@ func (r PKHResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolution
 	return &DIDResolutionResult{DIDDocument: *doc}, nil
 }
 
-func (r PKHResolver) Method() Method {
+func (PKHResolver) Method() Method {
 	return PKHMethod
 }

--- a/did/pkh_test.go
+++ b/did/pkh_test.go
@@ -133,7 +133,6 @@ func TestIsValidPKH(t *testing.T) {
 	assert.False(t, IsValidPKH("did:pkh:eip155:1:"))
 	assert.False(t, IsValidPKH("did:pkh:eip155::0xb9c5714089478a327f09197987f16f9e5d936e8a"))
 	assert.False(t, IsValidPKH("did:pkh:NOCAP:1:0xb9c5714089478a327f09197987f16f9e5d936e8a"))
-
 }
 
 func TestGetNetwork(t *testing.T) {

--- a/did/util.go
+++ b/did/util.go
@@ -72,7 +72,7 @@ func decodeEncodedKey(d string) ([]byte, cryptosuite.LDKeyType, error) {
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JsonWebKey2020, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:key: %d", multiCodecValue)
 		return nil, "", err
@@ -109,7 +109,7 @@ func decodePublicKeyWithType(data []byte) ([]byte, cryptosuite.LDKeyType, error)
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JsonWebKey2020, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:peer: %d", multiCodecValue)
 		return nil, "", err

--- a/did/util.go
+++ b/did/util.go
@@ -72,7 +72,7 @@ func decodeEncodedKey(d string) ([]byte, cryptosuite.LDKeyType, error) {
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Type, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:key: %d", multiCodecValue)
 		return nil, "", err
@@ -109,7 +109,7 @@ func decodePublicKeyWithType(data []byte) ([]byte, cryptosuite.LDKeyType, error)
 	case Secp256k1MultiCodec:
 		return pubKeyBytes, cryptosuite.EcdsaSecp256k1VerificationKey2019, nil
 	case P256MultiCodec, P384MultiCodec, P521MultiCodec, RSAMultiCodec:
-		return pubKeyBytes, cryptosuite.JSONWebKey2020Name, nil
+		return pubKeyBytes, cryptosuite.JSONWebKey2020Type, nil
 	default:
 		err := fmt.Errorf("unknown multicodec for did:peer: %d", multiCodecValue)
 		return nil, "", err

--- a/did/web.go
+++ b/did/web.go
@@ -45,7 +45,7 @@ func (d DIDWeb) Suffix() (string, error) {
 	return split[1], nil
 }
 
-func (d DIDWeb) Method() Method {
+func (DIDWeb) Method() Method {
 	return WebMethod
 }
 
@@ -128,16 +128,22 @@ func (d DIDWeb) GetDocURL() (string, error) {
 	// https://w3c-ccg.github.io/did-method-web/#optional-path-considerations
 	// Optional Path Considerations
 	var sb strings.Builder
-	sb.WriteString("https://" + decodedDomain + "/")
+	if _, err := sb.WriteString("https://" + decodedDomain + "/"); err != nil {
+		return "", err
+	}
 	for i := 3; i < numSubStrs; i++ {
 		str, err := url.QueryUnescape(subStrs[i])
 		if err != nil {
 			logrus.WithError(err).Errorf("url.QueryUnescape failed for subStr %s", subStrs[i])
 			return "", err
 		}
-		sb.WriteString(str + "/")
+		if _, err := sb.WriteString(str + "/"); err != nil {
+			return "", err
+		}
 	}
-	sb.WriteString(DIDWebDIDDocFilename)
+	if _, err := sb.WriteString(DIDWebDIDDocFilename); err != nil {
+		return "", err
+	}
 	return sb.String(), nil
 }
 
@@ -145,7 +151,7 @@ type WebResolver struct{}
 
 // Resolve fetches and returns the DIDDocument from the expected URL
 // specification: https://w3c-ccg.github.io/did-method-web/#read-resolve
-func (r WebResolver) Resolve(did string, opts ResolutionOptions) (*DIDResolutionResult, error) {
+func (WebResolver) Resolve(did string, _ ResolutionOptions) (*DIDResolutionResult, error) {
 	if !strings.HasPrefix(did, DIDWebPrefix) {
 		return nil, fmt.Errorf("not a did:web DID: %s", did)
 	}
@@ -188,7 +194,7 @@ func (d DIDWeb) ResolveDocBytes() ([]byte, error) {
 	// Specification https://w3c-ccg.github.io/did-method-web/#read-resolve
 	// 6. Perform an HTTP GET request to the URL using an agent that can successfully negotiate a secure HTTPS
 	// connection, which enforces the security requirements as described in 2.5 Security and privacy considerations.
-	resp, err := http.Get(docURL)
+	resp, err := http.Get(docURL) // #nosec
 	if err != nil {
 		logrus.WithError(err).Errorf("could not resolve with docURL %+v", docURL)
 		return nil, err
@@ -202,6 +208,6 @@ func (d DIDWeb) ResolveDocBytes() ([]byte, error) {
 	return body, nil
 }
 
-func (r WebResolver) Method() Method {
+func (WebResolver) Method() Method {
 	return WebMethod
 }

--- a/did/web_test.go
+++ b/did/web_test.go
@@ -1,11 +1,11 @@
 package did
 
 import (
+	"gopkg.in/h2non/gock.v1"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/h2non/gock.v1"
 )
 
 const (
@@ -36,14 +36,13 @@ func TestDIDWebGetURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com/user/alice/did.json", docURL)
 
-	docURL, err = didWebNotADomain.GetDocURL()
+	_, err = didWebNotADomain.GetDocURL()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing the required domain")
 
-	docURL, err = didWebBadQueryURL.GetDocURL()
+	_, err = didWebBadQueryURL.GetDocURL()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "url.QueryUnescape failed for subSt")
-
 }
 
 func TestDIDWebResolveDocBytes(t *testing.T) {
@@ -77,7 +76,6 @@ func TestDIDWebResolve(t *testing.T) {
 		doc, err := didWebToBeResolved.Resolve()
 		assert.NoError(tt, err)
 		assert.Equal(tt, string(didWebToBeResolved), doc.ID)
-
 	})
 
 	t.Run("Unhappy Path - Mismatched DID", func(tt *testing.T) {

--- a/error/response.go
+++ b/error/response.go
@@ -70,7 +70,8 @@ func NewErrorResponseWithErrorAndMsgf(errorType Type, err error, msg string, a .
 	}
 }
 
-// GetErrorResponse will get the type of err, if the type is a ErrorResponse it will return that as an ErrorResponse, otherwise it will construct a new default ErrorResponse
+// GetErrorResponse will get the type of err, if the type is a ErrorResponse it will return that as an ErrorResponse,
+// otherwise it will construct a new default ErrorResponse
 func GetErrorResponse(err error) Response {
 	var errRes *Response
 

--- a/example/did/did.go
+++ b/example/did/did.go
@@ -13,7 +13,6 @@ import (
 )
 
 func main() {
-
 	// Create a did:key. This is a specific did using the "key" method
 	// GenerateDIDKey takes in a key type value that this library supports and constructs a conformant did:key identifier.
 	// To use the private key, it is recommended to re-cast to the associated type.
@@ -39,5 +38,4 @@ func main() {
 		// Some basic DID information printed out here.
 		fmt.Printf("Generated DID document for did:key method:\n%s\n", string(dat))
 	}
-
 }

--- a/example/did/did_test.go
+++ b/example/did/did_test.go
@@ -2,8 +2,7 @@ package main
 
 import "testing"
 
-func TestDID(t *testing.T) {
-
+func TestDID(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/presentation/presentation.go
+++ b/example/presentation/presentation.go
@@ -2,12 +2,10 @@
 // Please see the actual source code documentation for more detailed information and specifications
 // for the specific methods. This is intended to give an overview and basic idea of how things work.
 
-//
 // |------------|       |----------------------|        |------------|
 // |  Verifier   | ----> | Presentation Request | -----> |   Holder   |
 // |            |       |      \Definition      |        |            |
 // |------------|       |----------------------|        |------------|
-//
 package main
 
 import (
@@ -53,14 +51,13 @@ func makePresentationData() exchange.PresentationDefinition {
 // and for the source code with the sdk,
 // https://github.com/TBD54566975/ssi-sdk/blob/main/credential/exchange/request.go
 // is appropriate to start off with.
-func makePresentationRequest(presentationData exchange.PresentationDefinition) (pr []byte, err error) {
-
+func makePresentationRequest(presentationData exchange.PresentationDefinition) ([]byte, error) {
 	// Generate JSON Web Key
 	// The JSONWebKey2020 type specifies a number of key type and curve pairs to enable JOSE conformance
 	// https://w3c-ccg.github.io/lds-jws2020/#dfn-jsonwebkey2020
 	jwk, err := cryptosuite.GenerateJSONWebKey2020(cryptosuite.OKP, cryptosuite.Ed25519)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Signer:
@@ -68,7 +65,7 @@ func makePresentationRequest(presentationData exchange.PresentationDefinition) (
 	// Implements: https://github.com/TBD54566975/ssi-sdk/blob/main/cryptosuite/jwt.go#L12
 	signer, err := crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Builds a presentation request
@@ -76,19 +73,19 @@ func makePresentationRequest(presentationData exchange.PresentationDefinition) (
 	// Target is the Audience Key
 	requestJWTBytes, err := exchange.BuildJWTPresentationRequest(*signer, presentationData, "did:test")
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// TODO: Add better documentation on the verification process
 	// Seems like needed to know more of: https://github.com/lestrrat-go/jwx/tree/develop/v2/jwt
 	verifier, err := cryptosuite.NewJSONWebKeyVerifier(jwk.ID, jwk.PublicKeyJWK)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	parsed, err := verifier.VerifyAndParseJWT(string(requestJWTBytes))
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if dat, err := util.PrettyJSON(parsed); err == nil {

--- a/example/presentation/presentation_test.go
+++ b/example/presentation/presentation_test.go
@@ -2,8 +2,7 @@ package main
 
 import "testing"
 
-func TestPresentation(t *testing.T) {
-
+func TestPresentation(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/usecase/apartment_application/apartment_application.go
+++ b/example/usecase/apartment_application/apartment_application.go
@@ -26,7 +26,6 @@ import (
 )
 
 func main() {
-
 	/**
 		 Step 1: Create new entities as DIDs. Govt Issuer, User Holder, and Apartment Verifier.
 	**/
@@ -59,10 +58,10 @@ func main() {
 	govtSigner, err := crypto.NewJWTSigner(govtDIDKey.String(), govtDIDJWK)
 	example.HandleExampleError(err, "Failed to generate signer")
 
-	fmt.Print("\n\nStep 1: Create new DIDs for entities\n\n")
-	fmt.Printf("Tenant: %s\n", string(*holderDIDKey))
-	fmt.Printf("Apartment: %s\n", string(*aptDIDKey))
-	fmt.Printf("Government: %s\n", string(*govtDIDKey))
+	_, _ = fmt.Print("\n\nStep 1: Create new DIDs for entities\n\n")
+	_, _ = fmt.Printf("Tenant: %s\n", string(*holderDIDKey))
+	_, _ = fmt.Printf("Apartment: %s\n", string(*aptDIDKey))
+	_, _ = fmt.Printf("Government: %s\n", string(*govtDIDKey))
 
 	/**
 		 Step 2: Government issuer issues a credential to the holder providing their age. The government issuer then signs the verifiable credentials to holder claiming age.
@@ -92,9 +91,9 @@ func main() {
 
 	example.HandleExampleError(err, "Failed to sign vc")
 
-	fmt.Print("\n\nStep 2: Government issues Verifiable Credential new for tenant verifying birthdate and signs\n\n")
+	_, _ = fmt.Print("\n\nStep 2: Government issues Verifiable Credential new for tenant verifying birthdate and signs\n\n")
 	if dat, err := util.PrettyJSON(vc); err == nil {
-		fmt.Printf("Verifiable Credential:%s\n", string(dat))
+		_, _ = fmt.Printf("Verifiable Credential:%s\n", string(dat))
 	}
 
 	/**
@@ -128,9 +127,9 @@ func main() {
 	presentationRequestBytes, err := exchange.BuildPresentationRequest(*aptSigner, exchange.JWTRequest, *presentationDefinition, string(*holderDIDKey))
 	example.HandleExampleError(err, "Failed to make presentation request")
 
-	fmt.Print("\n\nStep 3: The apartment creates a presentation request that confirms which information is required from the tenant\n\n")
+	_, _ = fmt.Print("\n\nStep 3: The apartment creates a presentation request that confirms which information is required from the tenant\n\n")
 	if dat, err := util.PrettyJSON(presentationDefinition); err == nil {
-		fmt.Printf("Presentation Definition that gets added to presentation request:%s\n", string(dat))
+		_, _ = fmt.Printf("Presentation Definition that gets added to presentation request:%s\n", string(dat))
 	}
 
 	/**
@@ -157,9 +156,9 @@ func main() {
 	presentationSubmissionBytes, err := exchange.BuildPresentationSubmission(*holderSigner, *presentationDefinition, []exchange.PresentationClaim{presentationClaim}, exchange.JWTVPTarget)
 	example.HandleExampleError(err, "Failed to create presentation submission")
 
-	fmt.Print("\n\nStep 4: The holder creates a presentation submission to give to the apartment\n\n")
+	_, _ = fmt.Print("\n\nStep 4: The holder creates a presentation submission to give to the apartment\n\n")
 	if dat, err := util.PrettyJSON(presentationClaim); err == nil {
-		fmt.Printf("Presentation Claim that gets added to presentation submission:%s\n", string(dat))
+		_, _ = fmt.Printf("Presentation Claim that gets added to presentation submission:%s\n", string(dat))
 	}
 
 	/**
@@ -169,7 +168,7 @@ func main() {
 	err = exchange.VerifyPresentationSubmission(*holderVerifier, exchange.JWTVPTarget, *presentationDefinition, presentationSubmissionBytes)
 	example.HandleExampleError(err, "Failed to verify presentation submission")
 
-	fmt.Print("\n\nStep 5: The apartment verifies that the presentation submission is valid and then can cryptographically verify that the birthdate of the tenant is authentic\n\n")
+	_, _ = fmt.Print("\n\nStep 5: The apartment verifies that the presentation submission is valid and then can cryptographically verify that the birthdate of the tenant is authentic\n\n")
 
-	fmt.Print("\n\n\n🎉 The tenant's age has now been verified and can now move into the apartment! 🎉\n\n\n")
+	_, _ = fmt.Print("\n\n\n🎉 The tenant's age has now been verified and can now move into the apartment! 🎉\n\n\n")
 }

--- a/example/usecase/apartment_application/apartment_application_test.go
+++ b/example/usecase/apartment_application/apartment_application_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestApartmentApplicationUseCase(t *testing.T) {
+func TestApartmentApplicationUseCase(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/usecase/employer_university_flow/main.go
+++ b/example/usecase/employer_university_flow/main.go
@@ -56,7 +56,6 @@ import (
 
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/example"
-	util "github.com/TBD54566975/ssi-sdk/example"
 	emp "github.com/TBD54566975/ssi-sdk/example/usecase/employer_university_flow/pkg"
 
 	"github.com/TBD54566975/ssi-sdk/credential/signing"
@@ -86,7 +85,6 @@ func init() {
 // 2. The student will store it in a "wallet"
 // 3. An employer sends a request to verify that the student graduated from the university.
 func main() {
-
 	step := 0
 
 	example.WriteStep("Starting University Flow", step)
@@ -97,24 +95,24 @@ func main() {
 	step += 1
 
 	student, err := emp.NewEntity("Student", "key")
-	util.HandleExampleError(err, "failed to create student")
+	example.HandleExampleError(err, "failed to create student")
 
 	example.WriteStep("Initializing Employer", step)
 	step += 1
 
 	employer, err := emp.NewEntity("Employer", "peer")
-	util.HandleExampleError(err, "failed to make employer identity")
+	example.HandleExampleError(err, "failed to make employer identity")
 	verifierDID, err := employer.GetWallet().GetDID("main")
-	util.HandleExampleError(err, "failed to create employer")
+	example.HandleExampleError(err, "failed to create employer")
 
 	example.WriteStep("Initializing University", step)
 	step += 1
 
 	university, err := emp.NewEntity("University", "peer")
-	util.HandleExampleError(err, "failed to create university")
+	example.HandleExampleError(err, "failed to create university")
 	vcDID, err := university.GetWallet().GetDID("main")
 
-	util.HandleExampleError(err, "failed to initialize verifier")
+	example.HandleExampleError(err, "failed to initialize verifier")
 	example.WriteNote(fmt.Sprintf("Initialized Verifier DID: %s and registered it", vcDID))
 	emp.TrustedEntities.Issuers[vcDID] = true
 
@@ -123,16 +121,16 @@ func main() {
 
 	example.WriteNote("DID is shared from holder")
 	holderDID, err := student.GetWallet().GetDID("main")
-	util.HandleExampleError(err, "failed to store did from university")
+	example.HandleExampleError(err, "failed to store did from university")
 
 	vc, err := emp.BuildExampleUniversityVC(vcDID, holderDID)
-	util.HandleExampleError(err, "failed to build vc")
+	example.HandleExampleError(err, "failed to build vc")
 
 	example.WriteStep("Example University Sends VC to Holder", step)
 	step += 1
 
 	err = student.GetWallet().AddCredentials(*vc)
-	util.HandleExampleError(err, "failed to add credentials to wallet")
+	example.HandleExampleError(err, "failed to add credentials to wallet")
 
 	msg := fmt.Sprintf("VC puts into wallet. Wallet size is now: %d", student.GetWallet().Size())
 	example.WriteNote(msg)
@@ -142,32 +140,32 @@ func main() {
 	step += 1
 
 	presentationData, err := emp.MakePresentationData("test-id", "id-1")
-	util.HandleExampleError(err, "failed to create pd")
+	example.HandleExampleError(err, "failed to create pd")
 
 	dat, err := json.Marshal(presentationData)
-	util.HandleExampleError(err, "failed to marshal presentation data")
+	example.HandleExampleError(err, "failed to marshal presentation data")
 	logrus.Debugf("Presentation Data:\n%v", string(dat))
 
 	jwk, err := cryptosuite.GenerateJSONWebKey2020(cryptosuite.OKP, cryptosuite.Ed25519)
-	util.HandleExampleError(err, "failed to generate json web key")
+	example.HandleExampleError(err, "failed to generate json web key")
 
 	presentationRequest, _, err := emp.MakePresentationRequest(*jwk, presentationData, holderDID)
-	util.HandleExampleError(err, "failed to make presentation request")
+	example.HandleExampleError(err, "failed to make presentation request")
 
 	verifier, err := crypto.NewJWTVerifier(jwk.ID, jwk.PublicKeyJWK)
-	util.HandleExampleError(err, "failed to build json web key verifier")
+	example.HandleExampleError(err, "failed to build json web key verifier")
 
 	signer, err := crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
-	util.HandleExampleError(err, "failed to build json web key signer")
+	example.HandleExampleError(err, "failed to build json web key signer")
 
 	example.WriteNote("Student returns claims via a Presentation Submission")
 	submission, err := emp.BuildPresentationSubmission(presentationRequest, *signer, *verifier, *vc)
-	util.HandleExampleError(err, "failed to build presentation submission")
+	example.HandleExampleError(err, "failed to build presentation submission")
 	vp, err := signing.VerifyVerifiablePresentationJWT(*verifier, string(submission))
-	util.HandleExampleError(err, "failed to verify jwt")
+	example.HandleExampleError(err, "failed to verify jwt")
 
 	dat, err = json.Marshal(vp)
-	util.HandleExampleError(err, "failed to marshal submission")
+	example.HandleExampleError(err, "failed to marshal submission")
 	logrus.Debugf("Submission:\n%v", string(dat))
 
 	example.WriteStep(fmt.Sprintf("Employer Attempting to Grant Access"), step)

--- a/example/usecase/employer_university_flow/main_test.go
+++ b/example/usecase/employer_university_flow/main_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestUniversityEmployerFlow(t *testing.T) {
+func TestUniversityEmployerFlow(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/usecase/employer_university_flow/pkg/issuer.go
+++ b/example/usecase/employer_university_flow/pkg/issuer.go
@@ -16,7 +16,6 @@ import (
 // VerifiableCredential is the verifiable credential model outlined in the vc-data-model spec:
 // https://www.w3.org/TR/2021/REC-vc-data-model-20211109/#basic-concept
 func BuildExampleUniversityVC(universityID, recipient string) (*credential.VerifiableCredential, error) {
-
 	knownContext := []string{"https://www.w3.org/2018/credentials/v1",
 		"https://www.w3.org/2018/credentials/examples/v1"} // JSON-LD context statement
 	knownID := "http://example.edu/credentials/1872"
@@ -57,11 +56,11 @@ func BuildExampleUniversityVC(universityID, recipient string) (*credential.Verif
 		return nil, err
 	}
 
-	if dat, err := json.Marshal(knownCred); err == nil {
-		logrus.Debug(string(dat))
-	} else {
+	dat, err := json.Marshal(knownCred)
+	if err != nil {
 		return nil, err
 	}
+	logrus.Debug(string(dat))
 
 	example.WriteNote(fmt.Sprintf("VC issued from %s to %s", universityID, recipient))
 

--- a/example/usecase/employer_university_flow/pkg/util.go
+++ b/example/usecase/employer_university_flow/pkg/util.go
@@ -39,11 +39,11 @@ func GenerateDIDPeer() (did.DID, error) {
 	if err != nil {
 		return nil, err
 	}
-	dID, err := did.PeerMethod0{}.Generate(kt, pubKey)
+	peer, err := did.PeerMethod0{}.Generate(kt, pubKey)
 	if err != nil {
 		return nil, err
 	}
-	return dID, nil
+	return peer, nil
 }
 
 // This validates the VC.

--- a/example/usecase/employer_university_flow/pkg/util.go
+++ b/example/usecase/employer_university_flow/pkg/util.go
@@ -39,35 +39,34 @@ func GenerateDIDPeer() (did.DID, error) {
 	if err != nil {
 		return nil, err
 	}
-	did, err := did.PeerMethod0{}.Generate(kt, pubKey)
+	dID, err := did.PeerMethod0{}.Generate(kt, pubKey)
 	if err != nil {
 		return nil, err
 	}
-	return did, nil
+	return dID, nil
 }
 
 // This validates the VC.
 // TODO: Expand on this more
 // Simplify it?
 func validateVC(vc credential.VerifiableCredential) error {
-
 	issuer := "https://example.edu/issuers/565049"
-	AssertionMethod := cryptosuite.ProofPurpose("assertionMethod")
+	assertionMethod := cryptosuite.ProofPurpose("assertionMethod")
 
 	var vc2 credential.VerifiableCredential
 	if err := util.Copy(&vc, &vc2); err != nil {
 		return err
 	}
 
-	var OKP = cryptosuite.KTY("OKP")
-	var Ed25519 = cryptosuite.CRV("Ed25519")
+	var okp = cryptosuite.KTY("OKP")
+	var ed25519 = cryptosuite.CRV("Ed25519")
 
-	jwk, err := cryptosuite.GenerateJSONWebKey2020(OKP, Ed25519)
+	jwk, err := cryptosuite.GenerateJSONWebKey2020(okp, ed25519)
 	if err != nil {
 		return err
 	}
 
-	signer, err := cryptosuite.NewJSONWebKeySigner(issuer, jwk.PrivateKeyJWK, AssertionMethod)
+	signer, err := cryptosuite.NewJSONWebKeySigner(issuer, jwk.PrivateKeyJWK, assertionMethod)
 	if err != nil {
 		return err
 	}
@@ -82,11 +81,7 @@ func validateVC(vc credential.VerifiableCredential) error {
 		return err
 	}
 
-	if err = suite.Verify(verifier, &vc2); err != nil {
-		return err
-	}
-
-	return nil
+	return suite.Verify(verifier, &vc2)
 }
 
 // MakePresentationRequest Builds a presentation request (PR). A PR is sent by a holder to a verifier. It can be sent
@@ -99,14 +94,14 @@ func MakePresentationRequest(jwk cryptosuite.JSONWebKey2020, presentationData ex
 	// Signer uses a JWK
 	signer, err = crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
 	if err != nil {
-		return
+		return nil, nil, err
 	}
 
 	// Builds a presentation request
 	// Requires a signer, the presentation data, and a target which is the Audience Key
 	requestJWTBytes, err := exchange.BuildJWTPresentationRequest(*signer, presentationData, targetID)
 	if err != nil {
-		return
+		return nil, nil, err
 	}
 
 	return requestJWTBytes, signer, err

--- a/example/usecase/employer_university_flow/pkg/util.go
+++ b/example/usecase/employer_university_flow/pkg/util.go
@@ -58,10 +58,7 @@ func validateVC(vc credential.VerifiableCredential) error {
 		return err
 	}
 
-	var okp = cryptosuite.KTY("OKP")
-	var ed25519 = cryptosuite.CRV("Ed25519")
-
-	jwk, err := cryptosuite.GenerateJSONWebKey2020(okp, ed25519)
+	jwk, err := cryptosuite.GenerateJSONWebKey2020(cryptosuite.OKP, cryptosuite.Ed25519)
 	if err != nil {
 		return err
 	}

--- a/example/usecase/steel_thread/steel_thread.go
+++ b/example/usecase/steel_thread/steel_thread.go
@@ -63,20 +63,20 @@ func (t *Entity) CreateCredentialApplication() {
 	t.credentialApplication = credApplication
 }
 
-func (t *Entity) SignCredentialManifest() {
+func (*Entity) SignCredentialManifest() {
 	// TODO: SignCredentialManifestJWT(issuer) -> JWTString
 }
 
-func (t *Entity) SignCredentialApplication() {
+func (*Entity) SignCredentialApplication() {
 	// TODO: SignCredentialApplicationJWT(issuer) -> JWTString
 }
 
-func (t *Entity) SignCredentialResponse() {
+func (*Entity) SignCredentialResponse() {
 	// TODO: SignCredentialResponseJWT(issuer) -> JWTString
 }
 
-func (t *Entity) SetCredentialManifest(manifest manifest.CredentialManifest) {
-	t.credentialManifest = manifest
+func (t *Entity) SetCredentialManifest(credManifest manifest.CredentialManifest) {
+	t.credentialManifest = credManifest
 }
 
 func (t *Entity) SetCredentialApplication(application manifest.CredentialApplication) {
@@ -107,7 +107,6 @@ func (t *Entity) ValidateCredentialResponse() error {
 }
 
 func (t *Entity) ValidateVerifiableCredentials() error {
-
 	for _, vc := range t.verifiableCredentials {
 		if vc.IsValid() != nil {
 			return vc.IsValid()
@@ -117,7 +116,6 @@ func (t *Entity) ValidateVerifiableCredentials() error {
 }
 
 func (t *Entity) ProcessCredentialApplication(issuer string, subject string) (*manifest.CredentialResponse, []credential.VerifiableCredential) {
-
 	var creds []credential.VerifiableCredential
 	for _, od := range t.credentialManifest.OutputDescriptors {
 		// TODO: Create Cred off of OD
@@ -136,7 +134,6 @@ func (t *Entity) ProcessCredentialApplication(issuer string, subject string) (*m
 
 	var descriptors []exchange.SubmissionDescriptor
 	for i, c := range creds {
-
 		format := string(exchange.JWTVC)
 
 		descriptors = append(descriptors, exchange.SubmissionDescriptor{
@@ -159,14 +156,13 @@ func (t *Entity) ProcessCredentialApplication(issuer string, subject string) (*m
 }
 
 func (t *Entity) FlexFullyValidatedCredentials() {
-	fmt.Print("\n#ShowingOffMyNewlyMintedCredentials: \n")
+	_, _ = fmt.Print("\n#ShowingOffMyNewlyMintedCredentials: \n")
 	for _, vc := range t.verifiableCredentials {
-		fmt.Print(vc.CredentialSubject)
+		_, _ = fmt.Print(vc.CredentialSubject)
 	}
 }
 
 func main() {
-
 	/**
 		Step 1: Alice creates a DID, stored in her wallet, didW
 	**/
@@ -265,7 +261,7 @@ func createCredentialApplication(cm manifest.CredentialManifest) manifest.Creden
 	return credApp
 }
 
-func createVerifiableCredential(issuerDID string, walletDID string, descriptor manifest.OutputDescriptor) credential.VerifiableCredential {
+func createVerifiableCredential(issuerDID string, walletDID string, _ manifest.OutputDescriptor) credential.VerifiableCredential {
 	vcBytes := getFileBytes("testdata/vc.json")
 
 	var vc credential.VerifiableCredential

--- a/example/usecase/steel_thread/steel_thread.go
+++ b/example/usecase/steel_thread/steel_thread.go
@@ -117,9 +117,9 @@ func (t *Entity) ValidateVerifiableCredentials() error {
 
 func (t *Entity) ProcessCredentialApplication(issuer string, subject string) (*manifest.CredentialResponse, []credential.VerifiableCredential) {
 	var creds []credential.VerifiableCredential
-	for _, od := range t.credentialManifest.OutputDescriptors {
+	for i := 0; i < len(t.credentialManifest.OutputDescriptors); i++ {
 		// TODO: Create Cred off of OD
-		creds = append(creds, createVerifiableCredential(issuer, subject, od))
+		creds = append(creds, createVerifiableCredential(issuer, subject))
 	}
 
 	responseBuilder := manifest.NewCredentialResponseBuilder(t.credentialManifest.ID)
@@ -261,7 +261,7 @@ func createCredentialApplication(cm manifest.CredentialManifest) manifest.Creden
 	return credApp
 }
 
-func createVerifiableCredential(issuerDID string, walletDID string, _ manifest.OutputDescriptor) credential.VerifiableCredential {
+func createVerifiableCredential(issuerDID string, walletDID string) credential.VerifiableCredential {
 	vcBytes := getFileBytes("testdata/vc.json")
 
 	var vc credential.VerifiableCredential

--- a/example/usecase/steel_thread/steel_thread_test.go
+++ b/example/usecase/steel_thread/steel_thread_test.go
@@ -2,7 +2,7 @@ package main
 
 import "testing"
 
-func TestSteelThreadUseCase(t *testing.T) {
+func TestSteelThreadUseCase(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/util.go
+++ b/example/util.go
@@ -19,7 +19,7 @@ const (
 func HandleExampleError(err error, msg string) {
 	if err != nil {
 		_, _ = os.Stderr.WriteString(fmt.Sprintf("%s: %v", msg, err))
-		os.Exit(1)
+		os.Exit(1) //revive:disable-line:deep-exit
 	}
 }
 

--- a/example/util_test.go
+++ b/example/util_test.go
@@ -2,8 +2,7 @@ package example
 
 import "testing"
 
-func TestUtil(t *testing.T) {
-
+func TestUtil(_ *testing.T) {
 	// If there is an error in main this test will fail
 	HandleExampleError(nil, "There should be no error")
 }

--- a/example/vc/vc.go
+++ b/example/vc/vc.go
@@ -11,7 +11,6 @@ import (
 )
 
 func main() {
-
 	// Make a Verifiable Credential using the VC data type directly. Alternatively, use the builder
 	// A VC is set of tamper-evident claims and metadata that cryptographically prove who issued it
 	// Building a VC means using the CredentialBuilder as part of the credentials package in the ssk-sdk.

--- a/example/vc/vc_test.go
+++ b/example/vc/vc_test.go
@@ -2,8 +2,7 @@ package main
 
 import "testing"
 
-func TestVC(t *testing.T) {
-
+func TestVC(_ *testing.T) {
 	// If there is an error in main this test will fail
 	main()
 }

--- a/example/wallet.go
+++ b/example/wallet.go
@@ -34,22 +34,20 @@ func NewSimpleWallet() *SimpleWallet {
 func (s *SimpleWallet) AddPrivateKey(k string, key gocrypto.PrivateKey) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	if _, ok := s.keys[k]; !ok {
-		s.keys[k] = key
-	} else {
+	if _, ok := s.keys[k]; ok {
 		return errors.New("already an entry")
 	}
+	s.keys[k] = key
 	return nil
 }
 
 func (s *SimpleWallet) AddDIDKey(k string, key string) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	if _, ok := s.dids[k]; !ok {
-		s.dids[k] = key
-	} else {
+	if _, ok := s.dids[k]; ok {
 		return errors.New("already an entry")
 	}
+	s.dids[k] = key
 	return nil
 }
 
@@ -69,11 +67,10 @@ func (s *SimpleWallet) AddCredentials(cred credential.VerifiableCredential) erro
 
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	if _, ok := s.vcs[cred.ID]; !ok {
-		s.vcs[cred.ID] = cred
-	} else {
+	if _, ok := s.vcs[cred.ID]; ok {
 		return fmt.Errorf("duplicate credential<%s>; could not add", cred.ID)
 	}
+	s.vcs[cred.ID] = cred
 	return nil
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -64,6 +64,18 @@ func runTests(extraTestArgs ...string) error {
 	return err
 }
 
+func Deps() error {
+	return brewInstall("golangci-lint")
+}
+
+func brewInstall(formula string) error {
+	return sh.Run("brew", "install", formula)
+}
+
+func Lint() error {
+	return sh.Run("golangci-lint", "run")
+}
+
 func ColorizeTestOutput(w io.Writer) io.Writer {
 	writer := NewRegexpWriter(w, `PASS.*`, "\033[32m$0\033[0m")
 	return NewRegexpWriter(writer, `FAIL.*`, "\033[31m$0\033[0m")

--- a/schema/jsonschema_test.go
+++ b/schema/jsonschema_test.go
@@ -81,7 +81,6 @@ func TestIsValidJSON(t *testing.T) {
 }
 
 func TestJSONSchemaValidation(t *testing.T) {
-
 	t.Run("Test Invalid JSON Against Schema", func(tt *testing.T) {
 		err := IsJSONValidAgainstSchema(string([]byte("bad")), string([]byte("bad")))
 		assert.Error(tt, err)


### PR DESCRIPTION
This PR includes:
* Adding mage `lint` and `deps` targets.
  * `lint` will run golangci-lint with the commited configuration. I disabled a number of checks for revive, and updated the source code so that they all passed. 
  * `deps` will install `golangci-lint` using homebrew.
* Added the `golangci-lint` action according to the [instructions](https://github.com/golangci/golangci-lint-action#how-to-use)

