### PR TITLE
Fix jwk usage

### DIFF
--- a/credential/exchange/request_test.go
+++ b/credential/exchange/request_test.go
@@ -3,12 +3,9 @@ package exchange
 import (
 	"testing"
 
-	"github.com/goccy/go-json"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/TBD54566975/ssi-sdk/crypto"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildPresentationRequest(t *testing.T) {
@@ -16,10 +13,7 @@ func TestBuildPresentationRequest(t *testing.T) {
 		_, privKey, err := crypto.GenerateEd25519Key()
 		assert.NoError(t, err)
 
-		key, err := jwk.New(privKey)
-		require.NoError(t, err)
-
-		signer, err := crypto.NewJWTSigner("test-id", key)
+		signer, err := crypto.NewJWTSigner("test-id", privKey)
 		assert.NoError(t, err)
 
 		testDef := getDummyPresentationDefinition()
@@ -42,10 +36,7 @@ func TestBuildPresentationRequest(t *testing.T) {
 		_, privKey, err := crypto.GenerateEd25519Key()
 		assert.NoError(t, err)
 
-		key, err := jwk.New(privKey)
-		require.NoError(t, err)
-
-		signer, err := crypto.NewJWTSigner("test-id", key)
+		signer, err := crypto.NewJWTSigner("test-id", privKey)
 		assert.NoError(t, err)
 
 		testDef := getDummyPresentationDefinition()
@@ -68,10 +59,7 @@ func TestBuildPresentationRequest(t *testing.T) {
 		_, privKey, err := crypto.GenerateEd25519Key()
 		assert.NoError(t, err)
 
-		key, err := jwk.New(privKey)
-		require.NoError(t, err)
-
-		signer, err := crypto.NewJWTSigner("test-id", key)
+		signer, err := crypto.NewJWTSigner("test-id", privKey)
 		assert.NoError(t, err)
 
 		testDef := getDummyPresentationDefinition()

--- a/credential/exchange/submission_test.go
+++ b/credential/exchange/submission_test.go
@@ -791,7 +791,7 @@ func getJWKSignerVerifier(t *testing.T) (*crypto.JWTSigner, *crypto.JWTVerifier)
 	require.NoError(t, err)
 
 	kid := "test-key"
-	signer, err := crypto.NewJWTSigner(kid, key)
+	signer, err := crypto.NewJWTSignerFromJWK(kid, key)
 	require.NoError(t, err)
 
 	verifier, err := signer.ToVerifier()

--- a/credential/exchange/submission_test.go
+++ b/credential/exchange/submission_test.go
@@ -791,7 +791,7 @@ func getJWKSignerVerifier(t *testing.T) (*crypto.JWTSigner, *crypto.JWTVerifier)
 	require.NoError(t, err)
 
 	kid := "test-key"
-	signer, err := crypto.NewJWTSignerFromJWK(kid, key)
+	signer, err := crypto.NewJWTSignerFromKey(kid, key)
 	require.NoError(t, err)
 
 	verifier, err := signer.ToVerifier()

--- a/credential/manifest/validation_test.go
+++ b/credential/manifest/validation_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/cryptosuite"
 	"github.com/goccy/go-json"
-	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -411,9 +410,7 @@ func getValidTestCredManifestCredApplicationJWTCred(t *testing.T) (CredentialMan
 	// turn into a jwt
 	_, privKey, err := crypto.GenerateEd25519Key()
 	require.NoError(t, err)
-	key, err := jwk.New(privKey)
-	require.NoError(t, err)
-	signer, err := crypto.NewJWTSigner("test-kid", key)
+	signer, err := crypto.NewJWTSigner("test-kid", privKey)
 	require.NoError(t, err)
 	jwt, err := signing.SignVerifiableCredentialJWT(*signer, vc)
 	require.NoError(t, err)

--- a/credential/signing/jwt_test.go
+++ b/credential/signing/jwt_test.go
@@ -76,7 +76,7 @@ func getTestVectorKey0Signer(t *testing.T) crypto.JWTSigner {
 		D:   "pLMxJruKPovJlxF3Lu_x9Aw3qe2wcj5WhKUAXYLBjwE",
 	}
 
-	signer, err := crypto.NewJWTSigner(knownJWK.KID, knownJWK)
+	signer, err := crypto.NewJWTSignerFromJWK(knownJWK.KID, knownJWK)
 	assert.NoError(t, err)
 	return *signer
 }

--- a/credential/util/util_test.go
+++ b/credential/util/util_test.go
@@ -65,7 +65,7 @@ func TestCredentialsFromInterface(t *testing.T) {
 			D:   "pLMxJruKPovJlxF3Lu_x9Aw3qe2wcj5WhKUAXYLBjwE",
 		}
 
-		signer, err := crypto.NewJWTSigner(knownJWK.KID, knownJWK)
+		signer, err := crypto.NewJWTSignerFromJWK(knownJWK.KID, knownJWK)
 		assert.NoError(tt, err)
 
 		testCred := getTestCredential()

--- a/crypto/jwk.go
+++ b/crypto/jwk.go
@@ -76,6 +76,24 @@ func JWKToPublicKeyJWK(key jwk.Key) (*PublicKeyJWK, error) {
 	return &pubKeyJWK, nil
 }
 
+// PublicKeyToJWK converts a public key to a JWK
+func PublicKeyToJWK(key crypto.PublicKey) (jwk.Key, error) {
+	switch key.(type) {
+	case rsa.PublicKey:
+		return jwkKeyFromRSAPublicKey(key.(rsa.PublicKey))
+	case ed25519.PublicKey:
+		return jwkKeyFromEd25519PublicKey(key.(ed25519.PublicKey))
+	case x25519.PublicKey:
+		return jwkKeyFromX25519PublicKey(key.(x25519.PublicKey))
+	case secp256k1.PublicKey:
+		return jwkKeyFromSECP256k1PublicKey(key.(secp256k1.PublicKey))
+	case ecdsa.PublicKey:
+		return jwkKeyFromECDSAPublicKey(key.(ecdsa.PublicKey))
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", key)
+	}
+}
+
 // PublicKeyToPublicKeyJWK converts a public key to a PublicKeyJWK
 func PublicKeyToPublicKeyJWK(key crypto.PublicKey) (*PublicKeyJWK, error) {
 	switch key.(type) {
@@ -91,6 +109,24 @@ func PublicKeyToPublicKeyJWK(key crypto.PublicKey) (*PublicKeyJWK, error) {
 		return jwkFromECDSAPublicKey(key.(ecdsa.PublicKey))
 	default:
 		return nil, fmt.Errorf("unsupported public key type: %T", key)
+	}
+}
+
+// PrivateKeyToJWK converts a private key to a JWK
+func PrivateKeyToJWK(key crypto.PrivateKey) (jwk.Key, error) {
+	switch key.(type) {
+	case rsa.PrivateKey:
+		return jwkKeyFromRSAPrivateKey(key.(rsa.PrivateKey))
+	case ed25519.PrivateKey:
+		return jwkKeyFromEd25519PrivateKey(key.(ed25519.PrivateKey))
+	case x25519.PrivateKey:
+		return jwkKeyFromX25519PrivateKey(key.(x25519.PrivateKey))
+	case secp256k1.PrivateKey:
+		return jwkKeyFromSECP256k1PrivateKey(key.(secp256k1.PrivateKey))
+	case ecdsa.PrivateKey:
+		return jwkKeyFromECDSAPrivateKey(key.(ecdsa.PrivateKey))
+	default:
+		return nil, fmt.Errorf("unsupported private key type: %T", key)
 	}
 }
 
@@ -110,6 +146,15 @@ func PrivateKeyToPrivateKeyJWK(key crypto.PrivateKey) (*PublicKeyJWK, *PrivateKe
 	default:
 		return nil, nil, fmt.Errorf("unsupported private key type: %T", key)
 	}
+}
+
+// jwkKeyFromRSAPrivateKey converts a RSA private key to a JWK
+func jwkKeyFromRSAPrivateKey(key rsa.PrivateKey) (jwk.Key, error) {
+	rsaJWK := jwk.NewRSAPrivateKey()
+	if err := rsaJWK.FromRaw(&key); err != nil {
+		return nil, errors.Wrap(err, "failed to generate rsa jwk")
+	}
+	return rsaJWK, nil
 }
 
 // jwkFromRSAPrivateKey converts a RSA private key to a JWK
@@ -141,6 +186,15 @@ func jwkFromRSAPrivateKey(key rsa.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK, er
 	return &publicKeyJWK, &privateKeyJWK, nil
 }
 
+// jwkKeyFromRSAPublicKey converts a RSA public key to a JWK
+func jwkKeyFromRSAPublicKey(key rsa.PublicKey) (jwk.Key, error) {
+	rsaJWK := jwk.NewRSAPublicKey()
+	if err := rsaJWK.FromRaw(&key); err != nil {
+		return nil, errors.Wrap(err, "failed to generate rsa jwk")
+	}
+	return rsaJWK, nil
+}
+
 // jwkFromRSAPublicKey converts a RSA public key to a JWK
 func jwkFromRSAPublicKey(key rsa.PublicKey) (*PublicKeyJWK, error) {
 	rsaJWK := jwk.NewRSAPublicKey()
@@ -155,6 +209,15 @@ func jwkFromRSAPublicKey(key rsa.PublicKey) (*PublicKeyJWK, error) {
 		N:   n,
 		E:   e,
 	}, nil
+}
+
+// jwkKeyFromEd25519PrivateKey converts a Ed25519 private key to a JWK
+func jwkKeyFromEd25519PrivateKey(key ed25519.PrivateKey) (jwk.Key, error) {
+	ed25519JWK := jwk.NewOKPPrivateKey()
+	if err := ed25519JWK.FromRaw(key); err != nil {
+		return nil, errors.Wrap(err, "failed to generate ed25519 jwk")
+	}
+	return ed25519JWK, nil
 }
 
 // jwkFromEd25519PrivateKey converts a Ed25519 private key to a JWK
@@ -181,6 +244,15 @@ func jwkFromEd25519PrivateKey(key ed25519.PrivateKey) (*PublicKeyJWK, *PrivateKe
 	return &publicKeyJWK, &privateKeyJWK, nil
 }
 
+// jwkKeyFromEd25519PublicKey converts a Ed25519 public key to a JWK
+func jwkKeyFromEd25519PublicKey(key ed25519.PublicKey) (jwk.Key, error) {
+	ed25519JWK := jwk.NewOKPPublicKey()
+	if err := ed25519JWK.FromRaw(key); err != nil {
+		return nil, errors.Wrap(err, "failed to generate ed25519 jwk")
+	}
+	return ed25519JWK, nil
+}
+
 // jwkFromEd25519PublicKey converts a Ed25519 public key to a JWK
 func jwkFromEd25519PublicKey(key ed25519.PublicKey) (*PublicKeyJWK, error) {
 	ed25519JWK := jwk.NewOKPPublicKey()
@@ -198,8 +270,18 @@ func jwkFromEd25519PublicKey(key ed25519.PublicKey) (*PublicKeyJWK, error) {
 }
 
 // jwkFromX25519PrivateKey converts a X25519 private key to a JWK
+func jwkKeyFromX25519PrivateKey(key x25519.PrivateKey) (jwk.Key, error) {
+	return jwkKeyFromEd25519PrivateKey(ed25519.PrivateKey(key))
+}
+
+// jwkFromX25519PrivateKey converts a X25519 private key to a JWK
 func jwkFromX25519PrivateKey(key x25519.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK, error) {
 	return jwkFromEd25519PrivateKey(ed25519.PrivateKey(key))
+}
+
+// jwkKeyFromX25519PublicKey converts a X25519 public key to a JWK
+func jwkKeyFromX25519PublicKey(key x25519.PublicKey) (jwk.Key, error) {
+	return jwkKeyFromEd25519PublicKey(ed25519.PublicKey(key))
 }
 
 // jwkFromX25519PublicKey converts a X25519 public key to a JWK
@@ -207,12 +289,24 @@ func jwkFromX25519PublicKey(key x25519.PublicKey) (*PublicKeyJWK, error) {
 	return jwkFromEd25519PublicKey(ed25519.PublicKey(key))
 }
 
+// jwkKeyFromSECP256k1PrivateKey converts a SECP256k1 private key to a JWK
+func jwkKeyFromSECP256k1PrivateKey(key secp256k1.PrivateKey) (jwk.Key, error) {
+	ecdsaPrivKey := key.ToECDSA()
+	secp256k1JWK := jwk.NewECDSAPrivateKey()
+	if err := secp256k1JWK.FromRaw(ecdsaPrivKey); err != nil {
+		err = errors.Wrap(err, "failed to generate secp256k1 jwk")
+		logrus.WithError(err).Error("could not extract key from raw private key")
+		return nil, err
+	}
+	return secp256k1JWK, nil
+}
+
 // jwkFromSECP256k1PrivateKey converts a SECP256k1 private key to a JWK
 func jwkFromSECP256k1PrivateKey(key secp256k1.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK, error) {
 	ecdsaPrivKey := key.ToECDSA()
 	secp256k1JWK := jwk.NewECDSAPrivateKey()
 	if err := secp256k1JWK.FromRaw(ecdsaPrivKey); err != nil {
-		err := errors.Wrap(err, "failed to generate secp256k1 jwk")
+		err = errors.Wrap(err, "failed to generate secp256k1 jwk")
 		logrus.WithError(err).Error("could not extract key from raw private key")
 		return nil, nil, err
 	}
@@ -237,12 +331,24 @@ func jwkFromSECP256k1PrivateKey(key secp256k1.PrivateKey) (*PublicKeyJWK, *Priva
 	return &publicKeyJWK, &privateKeyJWK, nil
 }
 
+// jwkKeyFromSECP256k1PublicKey converts a SECP256k1 public key to a JWK
+func jwkKeyFromSECP256k1PublicKey(key secp256k1.PublicKey) (jwk.Key, error) {
+	ecdsaPubKey := key.ToECDSA()
+	secp256k1JWK := jwk.NewECDSAPublicKey()
+	if err := secp256k1JWK.FromRaw(ecdsaPubKey); err != nil {
+		err = errors.Wrap(err, "failed to generate secp256k1 jwk")
+		logrus.WithError(err).Error("could not extract key from raw public key")
+		return nil, err
+	}
+	return secp256k1JWK, nil
+}
+
 // jwkFromSECP256k1PublicKey converts a SECP256k1 public key to a JWK
 func jwkFromSECP256k1PublicKey(key secp256k1.PublicKey) (*PublicKeyJWK, error) {
 	ecdsaPubKey := key.ToECDSA()
 	secp256k1JWK := jwk.NewECDSAPublicKey()
 	if err := secp256k1JWK.FromRaw(ecdsaPubKey); err != nil {
-		err := errors.Wrap(err, "failed to generate secp256k1 jwk")
+		err = errors.Wrap(err, "failed to generate secp256k1 jwk")
 		logrus.WithError(err).Error("could not extract key from raw public key")
 		return nil, err
 	}
@@ -256,6 +362,17 @@ func jwkFromSECP256k1PublicKey(key secp256k1.PublicKey) (*PublicKeyJWK, error) {
 		X:   x,
 		Y:   y,
 	}, nil
+}
+
+// jwkKeyFromECDSAPrivateKey converts a ECDSA private key to a JWK
+func jwkKeyFromECDSAPrivateKey(key ecdsa.PrivateKey) (jwk.Key, error) {
+	ecdsaKey := jwk.NewECDSAPrivateKey()
+	if err := ecdsaKey.FromRaw(&key); err != nil {
+		err = errors.Wrap(err, "failed to generate ecdsa jwk")
+		logrus.WithError(err).Error("could not extract key from raw private key")
+		return nil, err
+	}
+	return ecdsaKey, nil
 }
 
 // jwkFromECDSAPrivateKey converts a ECDSA private key to a JWK
@@ -285,6 +402,17 @@ func jwkFromECDSAPrivateKey(key ecdsa.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK
 		D:   encodeToBase64RawURL(ecdsaKey.D()),
 	}
 	return &publicKeyJWK, &privateKeyJWK, nil
+}
+
+// jwkKeyFromECDSAPublicKey converts a ECDSA public key to a JWK
+func jwkKeyFromECDSAPublicKey(key ecdsa.PublicKey) (jwk.Key, error) {
+	ecdsaKey := jwk.NewECDSAPublicKey()
+	if err := ecdsaKey.FromRaw(&key); err != nil {
+		err = errors.Wrap(err, "failed to generate ecdsa jwk")
+		logrus.WithError(err).Error("could not extract key from raw private key")
+		return nil, err
+	}
+	return ecdsaKey, nil
 }
 
 // jwkFromECDSAPublicKey converts a ECDSA public key to a JWK

--- a/crypto/jwk.go
+++ b/crypto/jwk.go
@@ -70,7 +70,7 @@ func JWKToPublicKeyJWK(key jwk.Key) (*PublicKeyJWK, error) {
 		return nil, err
 	}
 	var pubKeyJWK PublicKeyJWK
-	if err := json.Unmarshal(keyBytes, &pubKeyJWK); err != nil {
+	if err = json.Unmarshal(keyBytes, &pubKeyJWK); err != nil {
 		return nil, err
 	}
 	return &pubKeyJWK, nil
@@ -78,37 +78,37 @@ func JWKToPublicKeyJWK(key jwk.Key) (*PublicKeyJWK, error) {
 
 // PublicKeyToJWK converts a public key to a JWK
 func PublicKeyToJWK(key crypto.PublicKey) (jwk.Key, error) {
-	switch key.(type) {
+	switch k := key.(type) {
 	case rsa.PublicKey:
-		return jwkKeyFromRSAPublicKey(key.(rsa.PublicKey))
+		return jwkKeyFromRSAPublicKey(k)
 	case ed25519.PublicKey:
-		return jwkKeyFromEd25519PublicKey(key.(ed25519.PublicKey))
+		return jwkKeyFromEd25519PublicKey(k)
 	case x25519.PublicKey:
-		return jwkKeyFromX25519PublicKey(key.(x25519.PublicKey))
+		return jwkKeyFromX25519PublicKey(k)
 	case secp256k1.PublicKey:
-		return jwkKeyFromSECP256k1PublicKey(key.(secp256k1.PublicKey))
+		return jwkKeyFromSECP256k1PublicKey(k)
 	case ecdsa.PublicKey:
-		return jwkKeyFromECDSAPublicKey(key.(ecdsa.PublicKey))
+		return jwkKeyFromECDSAPublicKey(k)
 	default:
-		return nil, fmt.Errorf("unsupported public key type: %T", key)
+		return nil, fmt.Errorf("unsupported public key type: %T", k)
 	}
 }
 
 // PublicKeyToPublicKeyJWK converts a public key to a PublicKeyJWK
 func PublicKeyToPublicKeyJWK(key crypto.PublicKey) (*PublicKeyJWK, error) {
-	switch key.(type) {
+	switch k := key.(type) {
 	case rsa.PublicKey:
-		return jwkFromRSAPublicKey(key.(rsa.PublicKey))
+		return jwkFromRSAPublicKey(k)
 	case ed25519.PublicKey:
-		return jwkFromEd25519PublicKey(key.(ed25519.PublicKey))
+		return jwkFromEd25519PublicKey(k)
 	case x25519.PublicKey:
-		return jwkFromX25519PublicKey(key.(x25519.PublicKey))
+		return jwkFromX25519PublicKey(k)
 	case secp256k1.PublicKey:
-		return jwkFromSECP256k1PublicKey(key.(secp256k1.PublicKey))
+		return jwkFromSECP256k1PublicKey(k)
 	case ecdsa.PublicKey:
-		return jwkFromECDSAPublicKey(key.(ecdsa.PublicKey))
+		return jwkFromECDSAPublicKey(k)
 	default:
-		return nil, fmt.Errorf("unsupported public key type: %T", key)
+		return nil, fmt.Errorf("unsupported public key type: %T", k)
 	}
 }
 
@@ -126,25 +126,25 @@ func PrivateKeyToJWK(key crypto.PrivateKey) (jwk.Key, error) {
 	case ecdsa.PrivateKey:
 		return jwkKeyFromECDSAPrivateKey(k)
 	default:
-		return nil, fmt.Errorf("unsupported private key type: %T", key)
+		return nil, fmt.Errorf("unsupported private key type: %T", k)
 	}
 }
 
 // PrivateKeyToPrivateKeyJWK converts a private key to a PrivateKeyJWK
 func PrivateKeyToPrivateKeyJWK(key crypto.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK, error) {
-	switch key.(type) {
+	switch k := key.(type) {
 	case rsa.PrivateKey:
-		return jwkFromRSAPrivateKey(key.(rsa.PrivateKey))
+		return jwkFromRSAPrivateKey(k)
 	case ed25519.PrivateKey:
-		return jwkFromEd25519PrivateKey(key.(ed25519.PrivateKey))
+		return jwkFromEd25519PrivateKey(k)
 	case x25519.PrivateKey:
-		return jwkFromX25519PrivateKey(key.(x25519.PrivateKey))
+		return jwkFromX25519PrivateKey(k)
 	case secp256k1.PrivateKey:
-		return jwkFromSECP256k1PrivateKey(key.(secp256k1.PrivateKey))
+		return jwkFromSECP256k1PrivateKey(k)
 	case ecdsa.PrivateKey:
-		return jwkFromECDSAPrivateKey(key.(ecdsa.PrivateKey))
+		return jwkFromECDSAPrivateKey(k)
 	default:
-		return nil, nil, fmt.Errorf("unsupported private key type: %T", key)
+		return nil, nil, fmt.Errorf("unsupported private key type: %T", k)
 	}
 }
 

--- a/crypto/jwk.go
+++ b/crypto/jwk.go
@@ -57,7 +57,7 @@ func JWKToPrivateKeyJWK(key jwk.Key) (*PrivateKeyJWK, error) {
 		return nil, err
 	}
 	var privateKeyJWK PrivateKeyJWK
-	if err := json.Unmarshal(keyBytes, &privateKeyJWK); err != nil {
+	if err = json.Unmarshal(keyBytes, &privateKeyJWK); err != nil {
 		return nil, err
 	}
 	return &privateKeyJWK, nil
@@ -262,7 +262,7 @@ func jwkFromSECP256k1PublicKey(key secp256k1.PublicKey) (*PublicKeyJWK, error) {
 func jwkFromECDSAPrivateKey(key ecdsa.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK, error) {
 	ecdsaKey := jwk.NewECDSAPrivateKey()
 	if err := ecdsaKey.FromRaw(&key); err != nil {
-		err := errors.Wrap(err, "failed to generate ecdsa jwk")
+		err = errors.Wrap(err, "failed to generate ecdsa jwk")
 		logrus.WithError(err).Error("could not extract key from raw private key")
 		return nil, nil, err
 	}
@@ -291,7 +291,7 @@ func jwkFromECDSAPrivateKey(key ecdsa.PrivateKey) (*PublicKeyJWK, *PrivateKeyJWK
 func jwkFromECDSAPublicKey(key ecdsa.PublicKey) (*PublicKeyJWK, error) {
 	ecdsaKey := jwk.NewECDSAPublicKey()
 	if err := ecdsaKey.FromRaw(&key); err != nil {
-		err := errors.Wrap(err, "failed to generate ecdsa jwk")
+		err = errors.Wrap(err, "failed to generate ecdsa jwk")
 		logrus.WithError(err).Error("could not extract key from raw private key")
 		return nil, err
 	}

--- a/crypto/jwk.go
+++ b/crypto/jwk.go
@@ -114,17 +114,17 @@ func PublicKeyToPublicKeyJWK(key crypto.PublicKey) (*PublicKeyJWK, error) {
 
 // PrivateKeyToJWK converts a private key to a JWK
 func PrivateKeyToJWK(key crypto.PrivateKey) (jwk.Key, error) {
-	switch key.(type) {
+	switch k := key.(type) {
 	case rsa.PrivateKey:
-		return jwkKeyFromRSAPrivateKey(key.(rsa.PrivateKey))
+		return jwkKeyFromRSAPrivateKey(k)
 	case ed25519.PrivateKey:
-		return jwkKeyFromEd25519PrivateKey(key.(ed25519.PrivateKey))
+		return jwkKeyFromEd25519PrivateKey(k)
 	case x25519.PrivateKey:
-		return jwkKeyFromX25519PrivateKey(key.(x25519.PrivateKey))
+		return jwkKeyFromX25519PrivateKey(k)
 	case secp256k1.PrivateKey:
-		return jwkKeyFromSECP256k1PrivateKey(key.(secp256k1.PrivateKey))
+		return jwkKeyFromSECP256k1PrivateKey(k)
 	case ecdsa.PrivateKey:
-		return jwkKeyFromECDSAPrivateKey(key.(ecdsa.PrivateKey))
+		return jwkKeyFromECDSAPrivateKey(k)
 	default:
 		return nil, fmt.Errorf("unsupported private key type: %T", key)
 	}

--- a/crypto/jwt.go
+++ b/crypto/jwt.go
@@ -31,6 +31,17 @@ func NewJWTSigner(kid string, key crypto.PrivateKey) (*JWTSigner, error) {
 	}, nil
 }
 
+func NewJWTSignerFromJWK(kid string, key PrivateKeyJWK) (*JWTSigner, error) {
+	gotJWK, alg, err := jwtSignerVerifier(kid, key)
+	if err != nil {
+		return nil, err
+	}
+	return &JWTSigner{
+		SignatureAlgorithm: *alg,
+		Key:                gotJWK,
+	}, nil
+}
+
 func (sv *JWTSigner) ToVerifier() (*JWTVerifier, error) {
 	key, err := sv.Key.PublicKey()
 	if err != nil {

--- a/crypto/jwt_test.go
+++ b/crypto/jwt_test.go
@@ -44,7 +44,7 @@ func TestJsonWebSignature2020TestVectorJWT(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSignVerifyJWTForEachKeyType(t *testing.T) {
+func TestSignVerifyJWTForEachSupportedKeyType(t *testing.T) {
 	testKID := "test-kid"
 	testData := map[string]interface{}{
 		"test": "data",
@@ -57,13 +57,7 @@ func TestSignVerifyJWTForEachKeyType(t *testing.T) {
 			kt: Ed25519,
 		},
 		{
-			kt: X25519,
-		},
-		{
 			kt: SECP256k1,
-		},
-		{
-			kt: P224,
 		},
 		{
 			kt: P256,

--- a/crypto/jwt_test.go
+++ b/crypto/jwt_test.go
@@ -44,6 +44,68 @@ func TestJsonWebSignature2020TestVectorJWT(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSignVerifyJWTForEachKeyType(t *testing.T) {
+	testKID := "test-kid"
+	testData := map[string]interface{}{
+		"test": "data",
+	}
+
+	tests := []struct {
+		kt KeyType
+	}{
+		{
+			kt: Ed25519,
+		},
+		{
+			kt: X25519,
+		},
+		{
+			kt: SECP256k1,
+		},
+		{
+			kt: P224,
+		},
+		{
+			kt: P256,
+		},
+		{
+			kt: P384,
+		},
+		{
+			kt: P521,
+		},
+		{
+			kt: RSA,
+		},
+	}
+	for _, test := range tests {
+		t.Run(string(test.kt), func(t *testing.T) {
+			// generate a new key based on the given key type
+			_, privKey, err := GenerateKeyByKeyType(test.kt)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, privKey)
+
+			// create key access with the key
+			signer, err := NewJWTSigner(testKID, privKey)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, signer)
+
+			// sign
+			token, err := signer.SignJWT(testData)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, token)
+
+			// verify
+			verifier, err := signer.ToVerifier()
+			assert.NoError(t, err)
+			assert.NotEmpty(t, verifier)
+
+			err = verifier.VerifyJWT(string(token))
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestSignVerifyGenericJWT(t *testing.T) {
 	signer := getTestVectorKey0Signer(t)
 	verifier, err := signer.ToVerifier()
@@ -109,7 +171,7 @@ func getTestVectorKey0Signer(t *testing.T) JWTSigner {
 		D:   "pLMxJruKPovJlxF3Lu_x9Aw3qe2wcj5WhKUAXYLBjwE",
 	}
 
-	signer, err := NewJWTSigner(knownJWK.KID, knownJWK)
+	signer, err := NewJWTSignerFromJWK(knownJWK.KID, knownJWK)
 	assert.NoError(t, err)
 	return *signer
 }

--- a/cryptosuite/jsonwebkey2020.go
+++ b/cryptosuite/jsonwebkey2020.go
@@ -265,7 +265,7 @@ func (v *JSONWebKeyVerifier) GetKeyType() string {
 }
 
 func NewJSONWebKeyVerifier(kid string, key crypto.PublicKeyJWK) (*JSONWebKeyVerifier, error) {
-	verifier, err := crypto.NewJWTVerifier(kid, key)
+	verifier, err := crypto.NewJWTVerifierFromJWK(kid, key)
 	if err != nil {
 		return nil, err
 	}

--- a/cryptosuite/jsonwebkey2020.go
+++ b/cryptosuite/jsonwebkey2020.go
@@ -229,7 +229,7 @@ func (s *JSONWebKeySigner) GetPayloadFormat() PayloadFormat {
 }
 
 func NewJSONWebKeySigner(kid string, key crypto.PrivateKeyJWK, purpose ProofPurpose) (*JSONWebKeySigner, error) {
-	signer, err := crypto.NewJWTSigner(kid, key)
+	signer, err := crypto.NewJWTSignerFromJWK(kid, key)
 	if err != nil {
 		return nil, err
 	}

--- a/example/presentation/presentation.go
+++ b/example/presentation/presentation.go
@@ -63,7 +63,7 @@ func makePresentationRequest(presentationData exchange.PresentationDefinition) (
 	// Signer:
 	// https://github.com/TBD54566975/ssi-sdk/blob/main/cryptosuite/jsonwebkey2020.go#L350
 	// Implements: https://github.com/TBD54566975/ssi-sdk/blob/main/cryptosuite/jwt.go#L12
-	signer, err := crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
+	signer, err := crypto.NewJWTSignerFromJWK(jwk.ID, jwk.PrivateKeyJWK)
 	if err != nil {
 		return nil, err
 	}

--- a/example/usecase/apartment_application/apartment_application.go
+++ b/example/usecase/apartment_application/apartment_application.go
@@ -22,7 +22,6 @@ import (
 	"github.com/TBD54566975/ssi-sdk/example"
 	"github.com/TBD54566975/ssi-sdk/util"
 	"github.com/goccy/go-json"
-	"github.com/lestrrat-go/jwx/jwk"
 )
 
 func main() {
@@ -33,9 +32,7 @@ func main() {
 	// User Holder
 	holderDIDPrivateKey, holderDIDKey, err := did.GenerateDIDKey(crypto.Ed25519)
 	example.HandleExampleError(err, "Failed to generate DID")
-	holderDIDWJWK, err := jwk.New(holderDIDPrivateKey)
-	example.HandleExampleError(err, "Failed to generate JWK")
-	holderSigner, err := crypto.NewJWTSigner(holderDIDKey.String(), holderDIDWJWK)
+	holderSigner, err := crypto.NewJWTSigner(holderDIDKey.String(), holderDIDPrivateKey)
 	example.HandleExampleError(err, "Failed to generate signer")
 	holderVerifier, err := holderSigner.ToVerifier()
 	example.HandleExampleError(err, "Failed to generate verifier")
@@ -43,9 +40,7 @@ func main() {
 	// Apt Verifier
 	aptDIDPrivateKey, aptDIDKey, err := did.GenerateDIDKey(crypto.Ed25519)
 	example.HandleExampleError(err, "Failed to generate DID key")
-	aptDIDJWK, err := jwk.New(aptDIDPrivateKey)
-	example.HandleExampleError(err, "Failed to generate JWK")
-	aptSigner, err := crypto.NewJWTSigner(aptDIDKey.String(), aptDIDJWK)
+	aptSigner, err := crypto.NewJWTSigner(aptDIDKey.String(), aptDIDPrivateKey)
 	example.HandleExampleError(err, "Failed to generate signer")
 	aptVerifier, err := aptSigner.ToVerifier()
 	example.HandleExampleError(err, "Failed to generate verifier")
@@ -53,9 +48,7 @@ func main() {
 	// Government Issuer
 	govtDIDPrivateKey, govtDIDKey, err := did.GenerateDIDKey(crypto.Ed25519)
 	example.HandleExampleError(err, "Failed to generate DID key")
-	govtDIDJWK, err := jwk.New(govtDIDPrivateKey)
-	example.HandleExampleError(err, "Failed to generate JWK")
-	govtSigner, err := crypto.NewJWTSigner(govtDIDKey.String(), govtDIDJWK)
+	govtSigner, err := crypto.NewJWTSigner(govtDIDKey.String(), govtDIDPrivateKey)
 	example.HandleExampleError(err, "Failed to generate signer")
 
 	_, _ = fmt.Print("\n\nStep 1: Create new DIDs for entities\n\n")

--- a/example/usecase/employer_university_flow/main.go
+++ b/example/usecase/employer_university_flow/main.go
@@ -152,7 +152,7 @@ func main() {
 	presentationRequest, _, err := emp.MakePresentationRequest(*jwk, presentationData, holderDID)
 	example.HandleExampleError(err, "failed to make presentation request")
 
-	verifier, err := crypto.NewJWTVerifier(jwk.ID, jwk.PublicKeyJWK)
+	verifier, err := crypto.NewJWTVerifierFromJWK(jwk.ID, jwk.PublicKeyJWK)
 	example.HandleExampleError(err, "failed to build json web key verifier")
 
 	signer, err := crypto.NewJWTSignerFromJWK(jwk.ID, jwk.PrivateKeyJWK)

--- a/example/usecase/employer_university_flow/main.go
+++ b/example/usecase/employer_university_flow/main.go
@@ -155,7 +155,7 @@ func main() {
 	verifier, err := crypto.NewJWTVerifier(jwk.ID, jwk.PublicKeyJWK)
 	example.HandleExampleError(err, "failed to build json web key verifier")
 
-	signer, err := crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
+	signer, err := crypto.NewJWTSignerFromJWK(jwk.ID, jwk.PrivateKeyJWK)
 	example.HandleExampleError(err, "failed to build json web key signer")
 
 	example.WriteNote("Student returns claims via a Presentation Submission")

--- a/example/usecase/employer_university_flow/pkg/util.go
+++ b/example/usecase/employer_university_flow/pkg/util.go
@@ -89,7 +89,7 @@ func MakePresentationRequest(jwk cryptosuite.JSONWebKey2020, presentationData ex
 	example.WriteNote("Presentation Request (JWT) is created")
 
 	// Signer uses a JWK
-	signer, err = crypto.NewJWTSigner(jwk.ID, jwk.PrivateKeyJWK)
+	signer, err = crypto.NewJWTSignerFromJWK(jwk.ID, jwk.PrivateKeyJWK)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/example/usecase/steel_thread/steel_thread.go
+++ b/example/usecase/steel_thread/steel_thread.go
@@ -22,7 +22,6 @@ import (
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/did"
 	"github.com/TBD54566975/ssi-sdk/example"
-	"github.com/lestrrat-go/jwx/jwk"
 )
 
 type Entity struct {
@@ -42,9 +41,7 @@ var (
 func (t *Entity) GenerateWallet() {
 	walletDIDPrivateKey, walletDIDKey, err := did.GenerateDIDKey(crypto.Ed25519)
 	example.HandleExampleError(err, "Failed to generate DID")
-	walletDIDWJWK, err := jwk.New(walletDIDPrivateKey)
-	example.HandleExampleError(err, "Failed to generate JWK")
-	walletSigner, err := crypto.NewJWTSigner(walletDIDKey.String(), walletDIDWJWK)
+	walletSigner, err := crypto.NewJWTSigner(walletDIDKey.String(), walletDIDPrivateKey)
 	example.HandleExampleError(err, "Failed to generate signer")
 	walletVerifier, err := walletSigner.ToVerifier()
 	example.HandleExampleError(err, "Failed to generate verifier")


### PR DESCRIPTION
Support generating generic JWK objects. Add validation so that it's impossible to generate signers/verifiers with unsupported key types/algorithms.