### PR TITLE
Fix verification bug with JWT credentials

### DIFF
--- a/credential/exchange/verification.go
+++ b/credential/exchange/verification.go
@@ -123,7 +123,7 @@ func VerifyPresentationSubmissionVP(def PresentationDefinition, vp credential.Ve
 			logrus.WithError(err).Error()
 			return err
 		}
-		submittedClaim, err := getClaimAsJSON(claim)
+		submittedClaim, err := credutil.ClaimAsJSON(claim)
 		if err != nil {
 			err := errors.Wrapf(err, "getting claim as go-json: <%s>", claim)
 			logrus.WithError(err).Error()
@@ -148,28 +148,6 @@ func VerifyPresentationSubmissionVP(def PresentationDefinition, vp credential.Ve
 		}
 	}
 	return nil
-}
-
-func getClaimAsJSON(claim interface{}) (map[string]interface{}, error) {
-	switch c := claim.(type) {
-	case map[string]interface{}:
-		return c, nil
-	default:
-	}
-
-	vc, err := credutil.CredentialsFromInterface(claim)
-	if err != nil {
-		return nil, errors.Wrap(err, "credential from interface")
-	}
-	vcData, err := json.Marshal(vc)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshalling credential")
-	}
-	var submittedClaim map[string]interface{}
-	if err := json.Unmarshal(vcData, &submittedClaim); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling credential")
-	}
-	return submittedClaim, nil
 }
 
 func toPresentationSubmission(maybePresentationSubmission interface{}) (*PresentationSubmission, error) {

--- a/credential/util/util.go
+++ b/credential/util/util.go
@@ -39,3 +39,27 @@ func CredentialsFromInterface(genericCred interface{}) (*credential.VerifiableCr
 		return nil, fmt.Errorf("invalid credential type: %s", reflect.TypeOf(genericCred).Kind().String())
 	}
 }
+
+// ClaimAsJSON converts a claim with an unknown interface{} into the go-json representation of that credential.
+// claim can only be of type {string, map[string]interface, VerifiableCredential}.
+func ClaimAsJSON(claim interface{}) (map[string]interface{}, error) {
+	switch c := claim.(type) {
+	case map[string]interface{}:
+		return c, nil
+	default:
+	}
+
+	vc, err := CredentialsFromInterface(claim)
+	if err != nil {
+		return nil, errors.Wrap(err, "credential from interface")
+	}
+	vcData, err := json.Marshal(vc)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling credential")
+	}
+	var submittedClaim map[string]interface{}
+	if err := json.Unmarshal(vcData, &submittedClaim); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling credential")
+	}
+	return submittedClaim, nil
+}


### PR DESCRIPTION
This fixes a bug where the presentations were throwing errors when the verifiable credentials contained in them were JWTs (instead of elements of type `VerifiableCredential`).

The test I added fails before the changes, and passes after the updates. 