### PR TITLE
Handling pointers in key conversion

### DIFF
--- a/crypto/jwk.go
+++ b/crypto/jwk.go
@@ -81,14 +81,24 @@ func PublicKeyToJWK(key crypto.PublicKey) (jwk.Key, error) {
 	switch k := key.(type) {
 	case rsa.PublicKey:
 		return jwkKeyFromRSAPublicKey(k)
+	case *rsa.PublicKey:
+		return jwkKeyFromRSAPublicKey(*k)
 	case ed25519.PublicKey:
 		return jwkKeyFromEd25519PublicKey(k)
+	case *ed25519.PublicKey:
+		return jwkKeyFromEd25519PublicKey(*k)
 	case x25519.PublicKey:
 		return jwkKeyFromX25519PublicKey(k)
+	case *x25519.PublicKey:
+		return jwkKeyFromX25519PublicKey(*k)
 	case secp256k1.PublicKey:
 		return jwkKeyFromSECP256k1PublicKey(k)
+	case *secp256k1.PublicKey:
+		return jwkKeyFromSECP256k1PublicKey(*k)
 	case ecdsa.PublicKey:
 		return jwkKeyFromECDSAPublicKey(k)
+	case *ecdsa.PublicKey:
+		return jwkKeyFromECDSAPublicKey(*k)
 	default:
 		return nil, fmt.Errorf("unsupported public key type: %T", k)
 	}
@@ -99,14 +109,24 @@ func PublicKeyToPublicKeyJWK(key crypto.PublicKey) (*PublicKeyJWK, error) {
 	switch k := key.(type) {
 	case rsa.PublicKey:
 		return jwkFromRSAPublicKey(k)
+	case *rsa.PublicKey:
+		return jwkFromRSAPublicKey(*k)
 	case ed25519.PublicKey:
 		return jwkFromEd25519PublicKey(k)
+	case *ed25519.PublicKey:
+		return jwkFromEd25519PublicKey(*k)
 	case x25519.PublicKey:
 		return jwkFromX25519PublicKey(k)
+	case *x25519.PublicKey:
+		return jwkFromX25519PublicKey(*k)
 	case secp256k1.PublicKey:
 		return jwkFromSECP256k1PublicKey(k)
+	case *secp256k1.PublicKey:
+		return jwkFromSECP256k1PublicKey(*k)
 	case ecdsa.PublicKey:
 		return jwkFromECDSAPublicKey(k)
+	case *ecdsa.PublicKey:
+		return jwkFromECDSAPublicKey(*k)
 	default:
 		return nil, fmt.Errorf("unsupported public key type: %T", k)
 	}

--- a/crypto/jwk_test.go
+++ b/crypto/jwk_test.go
@@ -56,6 +56,11 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "RSA", jwk.KTY)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "RSA", jwk2.KTY)
 	})
 
 	t.Run("Ed25519", func(tt *testing.T) {
@@ -67,6 +72,12 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "OKP", jwk.KTY)
 		assert.Equal(tt, "Ed25519", jwk.CRV)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "OKP", jwk2.KTY)
+		assert.Equal(tt, "Ed25519", jwk2.CRV)
 	})
 
 	t.Run("X25519", func(tt *testing.T) {
@@ -78,6 +89,12 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "OKP", jwk.KTY)
 		assert.Equal(tt, "Ed25519", jwk.CRV)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "OKP", jwk2.KTY)
+		assert.Equal(tt, "Ed25519", jwk2.CRV)
 	})
 
 	t.Run("secp256k1", func(tt *testing.T) {
@@ -89,6 +106,12 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "EC", jwk.KTY)
 		assert.Equal(tt, "secp256k1", jwk.CRV)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "EC", jwk2.KTY)
+		assert.Equal(tt, "secp256k1", jwk2.CRV)
 	})
 
 	t.Run("ecdsa P-256", func(tt *testing.T) {
@@ -100,6 +123,12 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "EC", jwk.KTY)
 		assert.Equal(tt, "P-256", jwk.CRV)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "EC", jwk2.KTY)
+		assert.Equal(tt, "P-256", jwk2.CRV)
 	})
 
 	t.Run("ecdsa P-384", func(tt *testing.T) {
@@ -111,6 +140,12 @@ func TestPublicKeyToPublicKeyJWK(t *testing.T) {
 		assert.NotEmpty(tt, jwk)
 		assert.Equal(tt, "EC", jwk.KTY)
 		assert.Equal(tt, "P-384", jwk.CRV)
+
+		jwk2, err := PublicKeyToPublicKeyJWK(&pubKey)
+		assert.NoError(tt, err)
+		assert.NotEmpty(tt, jwk2)
+		assert.Equal(tt, "EC", jwk2.KTY)
+		assert.Equal(tt, "P-384", jwk2.CRV)
 	})
 
 	t.Run("unsupported", func(tt *testing.T) {


### PR DESCRIPTION
The `crypto.PublicKey` from the go-crypto package is of type `any`. This means that users may pass in multiple different things, including pointers to the types of the keys. 

This PR adds support for these conversions, along with tests. 