### PR TITLE
[WIP] #261: Add fuzz test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
 
       - name: Test
         run: mage citest
+      
+      - name: Fuzz tests
+        run: mage fuzz
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/did/key_fuzz_test.go
+++ b/did/key_fuzz_test.go
@@ -1,0 +1,56 @@
+package did
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var mockPubKeys = []string{
+	"b9c5714089478a327f09197987f16f9e5d936e8a", "5f246d7d19aa612d6718d27c1da1ee66859586b0", "7d2d43e63666f45b40316b44212325625dbaeb40", "1c1f02f1640e52b313f2d504b3c0c7ee8ad61108", "69c5888ecd21287fbdac5a43d1558bf73c51e38b",
+}
+
+func FuzzCreateAndDecode(f *testing.F) {
+	keytypes := GetSupportedDIDKeyTypes()
+	ktLen := len(keytypes)
+
+	for i, pk := range mockPubKeys {
+		f.Add(i, []byte(pk))
+	}
+	f.Fuzz(func(t *testing.T, ktSeed int, pubKey []byte) {
+		kt := keytypes[(ktSeed%ktLen+ktLen)%ktLen]
+
+		didKey, err := CreateDIDKey(kt, pubKey)
+		assert.NoError(t, err)
+
+		recvPubKey, _, _, err := didKey.Decode()
+		assert.NoError(t, err)
+		assert.Equal(t, pubKey, recvPubKey)
+	})
+}
+
+func FuzzCreateAndResolve(f *testing.F) {
+	keytypes := GetSupportedDIDKeyTypes()
+	ktLen := len(keytypes)
+
+	resolvers := []Resolution{KeyResolver{}, WebResolver{}, PKHResolver{}, PeerResolver{}}
+	resolver, _ := NewResolver(resolvers...)
+
+	for i, pk := range mockPubKeys {
+		f.Add(i, []byte(pk))
+	}
+
+	f.Fuzz(func(t *testing.T, ktSeed int, pubKey []byte) {
+		kt := keytypes[(ktSeed%ktLen+ktLen)%ktLen]
+
+		didKey, err := CreateDIDKey(kt, pubKey)
+		assert.NoError(t, err)
+
+		doc, err := resolver.Resolve(didKey.String())
+		if err != nil {
+			t.Skip()
+		}
+		assert.NotEmpty(t, doc)
+		assert.Equal(t, didKey.String(), doc.DIDDocument.ID)
+	})
+}


### PR DESCRIPTION
## Overview
WIP PR for [issue#261](https://github.com/TBD54566975/ssi-sdk/issues/261)

## Description
Adds:
- fuzz test for "Create and then resolve returns a document with the same ID".
- Unit tests for "Generate and then resolve returns a document with the same ID".

## How Has This Been Tested?
With commands:
`mage fuzz`
`mage test`

