### PR TITLE
Enable schema caching for tests

### DIFF
--- a/credential/manifest/schema_test.go
+++ b/credential/manifest/schema_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/TBD54566975/ssi-sdk/schema"
@@ -13,12 +14,12 @@ import (
 func TestMain(m *testing.M) {
 	localSchemas, err := schema.GetAllLocalSchemas()
 	if err != nil {
-		println(err)
+		logrus.WithError(err).Fatal()
 		os.Exit(1)
 	}
 	loader, err := schema.NewCachingLoader(localSchemas)
 	if err != nil {
-		println(err)
+		logrus.WithError(err).Fatal()
 		os.Exit(1)
 	}
 	loader.EnableHTTPCache()

--- a/credential/manifest/schema_test.go
+++ b/credential/manifest/schema_test.go
@@ -13,11 +13,15 @@ import (
 func TestMain(m *testing.M) {
 	localSchemas, err := schema.GetAllLocalSchemas()
 	if err != nil {
+		println(err)
 		os.Exit(1)
 	}
-	if _, err = schema.NewCachingLoader(localSchemas); err != nil {
+	loader, err := schema.NewCachingLoader(localSchemas)
+	if err != nil {
+		println(err)
 		os.Exit(1)
 	}
+	loader.EnableHTTPCache()
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
This makes tests run significantly faster. See below, where:
* Before changes: `32.108`
* After changes: `11.448`

```
➜  ssi-sdk git:(main) go clean -testcache; time go test -tags=jwx_es256k ./...             
ok      github.com/TBD54566975/ssi-sdk/credential       0.200s
ok      github.com/TBD54566975/ssi-sdk/credential/exchange      5.440s
ok      github.com/TBD54566975/ssi-sdk/credential/manifest      31.147s
ok      github.com/TBD54566975/ssi-sdk/credential/rendering     0.293s
ok      github.com/TBD54566975/ssi-sdk/credential/schema        0.342s
ok      github.com/TBD54566975/ssi-sdk/credential/signing       0.474s
ok      github.com/TBD54566975/ssi-sdk/credential/status        0.228s
ok      github.com/TBD54566975/ssi-sdk/credential/util  1.248s
ok      github.com/TBD54566975/ssi-sdk/credential/verification  0.409s
ok      github.com/TBD54566975/ssi-sdk/crypto   1.265s
ok      github.com/TBD54566975/ssi-sdk/cryptosuite      10.382s
ok      github.com/TBD54566975/ssi-sdk/did      1.534s
ok      github.com/TBD54566975/ssi-sdk/error    0.598s
ok      github.com/TBD54566975/ssi-sdk/example  0.634s
ok      github.com/TBD54566975/ssi-sdk/example/did      0.619s
ok      github.com/TBD54566975/ssi-sdk/example/presentation     0.539s
ok      github.com/TBD54566975/ssi-sdk/example/usecase/apartment_application    0.805s
ok      github.com/TBD54566975/ssi-sdk/example/usecase/employer_university_flow 0.365s
?       github.com/TBD54566975/ssi-sdk/example/usecase/employer_university_flow/pkg     [no test files]
ok      github.com/TBD54566975/ssi-sdk/example/usecase/steel_thread     1.094s
ok      github.com/TBD54566975/ssi-sdk/example/vc       0.156s
ok      github.com/TBD54566975/ssi-sdk/schema   0.332s
ok      github.com/TBD54566975/ssi-sdk/util     1.482s
?       github.com/TBD54566975/ssi-sdk/wasm/webserver   [no test files]
go test -tags=jwx_es256k ./...  10.23s user 2.37s system 39% cpu 32.108 total
➜  ssi-sdk git:(main) git stash pop
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   credential/manifest/schema_test.go

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (f2afd62511f6739149aac43a62a27a8dc4c08cf2)
➜  ssi-sdk git:(main) ✗ go clean -testcache; time go test -tags=jwx_es256k ./...
ok      github.com/TBD54566975/ssi-sdk/credential       0.266s
ok      github.com/TBD54566975/ssi-sdk/credential/exchange      5.787s
ok      github.com/TBD54566975/ssi-sdk/credential/manifest      0.962s
ok      github.com/TBD54566975/ssi-sdk/credential/rendering     0.136s
ok      github.com/TBD54566975/ssi-sdk/credential/schema        0.340s
ok      github.com/TBD54566975/ssi-sdk/credential/signing       0.439s
ok      github.com/TBD54566975/ssi-sdk/credential/status        0.208s
ok      github.com/TBD54566975/ssi-sdk/credential/util  1.182s
ok      github.com/TBD54566975/ssi-sdk/credential/verification  0.697s
ok      github.com/TBD54566975/ssi-sdk/crypto   0.747s
ok      github.com/TBD54566975/ssi-sdk/cryptosuite      10.721s
ok      github.com/TBD54566975/ssi-sdk/did      1.186s
ok      github.com/TBD54566975/ssi-sdk/error    0.602s
ok      github.com/TBD54566975/ssi-sdk/example  0.649s
ok      github.com/TBD54566975/ssi-sdk/example/did      0.532s
ok      github.com/TBD54566975/ssi-sdk/example/presentation     0.308s
ok      github.com/TBD54566975/ssi-sdk/example/usecase/apartment_application    0.809s
ok      github.com/TBD54566975/ssi-sdk/example/usecase/employer_university_flow 0.431s
?       github.com/TBD54566975/ssi-sdk/example/usecase/employer_university_flow/pkg     [no test files]
ok      github.com/TBD54566975/ssi-sdk/example/usecase/steel_thread     1.232s
ok      github.com/TBD54566975/ssi-sdk/example/vc       0.203s
ok      github.com/TBD54566975/ssi-sdk/schema   0.272s
ok      github.com/TBD54566975/ssi-sdk/util     1.557s
?       github.com/TBD54566975/ssi-sdk/wasm/webserver   [no test files]
go test -tags=jwx_es256k ./...  7.89s user 1.82s system 84% cpu 11.448 total
```