### PR TITLE
Add models for Credential Issuer Metadata

### DIFF
--- a/oidc/issuance/example_issuer_metadata.json
+++ b/oidc/issuance/example_issuer_metadata.json
@@ -1,0 +1,75 @@
+{
+  "credential_issuer": "https://credential-issuer.example.com",
+  "authorization_server": "https://auth-server.example.com",
+  "credential_endpoint": "https://credential-issuer.example.com/credentials",
+  "batch_credential_endpoint": "https://credential-issuer.example.com/batch-credentials",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alt_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "last_name": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "degree": {},
+        "gpa": {
+          "display": [
+            {
+              "name": "GPA"
+            }
+          ]
+        }
+      },
+      "order": [
+        "GPA",
+        "Given Name",
+        "Surname"
+      ]
+    }
+  ],
+  "display": [
+    {
+      "name": "issuer boss",
+      "locale": "en-US"
+    },
+    {
+      "name": "issuer jefe",
+      "locale": "es-CO"
+    }
+  ]
+}

--- a/oidc/issuance/metadata.go
+++ b/oidc/issuance/metadata.go
@@ -52,7 +52,7 @@ const (
 type CredentialSupported struct {
 	Format Format `json:"format" validate:"required"`
 
-	Id *string `json:"id,omitempty"`
+	ID *string `json:"id,omitempty"`
 
 	CryptographicBindingMethodsSupported []CryptographicBindingMethodSupported `json:"cryptographic_binding_methods_supported,omitempty"`
 
@@ -64,8 +64,8 @@ type CredentialSupported struct {
 	*JWTVCJSONCredentialMetadata
 }
 
-// DIDBindingMethods returns a list of all the did methods supported from the list of CryptographicBindingMethodsSupported.
-func (s CredentialSupported) DIDBindingMethods() []did.Method {
+// BindingDIDMethods returns a list of all the did methods supported from the list of CryptographicBindingMethodsSupported.
+func (s CredentialSupported) BindingDIDMethods() []did.Method {
 	methods := make([]did.Method, 0, len(s.CryptographicBindingMethodsSupported))
 	for _, bm := range s.CryptographicBindingMethodsSupported {
 		method, ok := bm.DIDBinding()
@@ -98,7 +98,7 @@ type IssuerMetadata struct {
 	// Must use the `https` scheme.
 	BatchCredentialEndpoint *util.URL `json:"batch_credential_endpoint,omitempty"`
 
-	CredentialsSupported []CredentialSupported `json:"credentials_supported,omitempty"`
+	CredentialsSupported CredentialSupported `json:"credentials_supported,omitempty"`
 
 	Display []displayJSON `json:"display,omitempty"`
 }
@@ -158,8 +158,7 @@ func (c Claim) MarshalJSON() ([]byte, error) {
 
 func (c *Claim) UnmarshalJSON(data []byte) error {
 	var cJSON claimJSON
-	err := json.Unmarshal(data, &cJSON)
-	if err != nil {
+	if err := json.Unmarshal(data, &cJSON); err != nil {
 		return errors.Wrap(err, "unmarshalling")
 	}
 	c.Mandatory = cJSON.Mandatory

--- a/oidc/issuance/metadata.go
+++ b/oidc/issuance/metadata.go
@@ -44,9 +44,9 @@ type CredentialDisplay struct {
 type Format string
 
 const (
-	JwtVcJSON   Format = "jwt_vc_json"
-	JwtVcJSONLd Format = "jwt_vc_json-ld"
-	LdpVc       Format = "ldp_vc"
+	JWTVCJSON   Format = "jwt_vc_json"
+	JWTVCJSONLD Format = "jwt_vc_json-ld"
+	LDPVC       Format = "ldp_vc"
 )
 
 type CredentialSupported struct {
@@ -98,7 +98,7 @@ type IssuerMetadata struct {
 	// Must use the `https` scheme.
 	BatchCredentialEndpoint *util.URL `json:"batch_credential_endpoint,omitempty"`
 
-	CredentialsSupported CredentialSupported `json:"credentials_supported,omitempty"`
+	CredentialsSupported []CredentialSupported `json:"credentials_supported,omitempty"`
 
 	Display []displayJSON `json:"display,omitempty"`
 }

--- a/oidc/issuance/metadata.go
+++ b/oidc/issuance/metadata.go
@@ -64,7 +64,7 @@ type CredentialSupported struct {
 	*JWTVCJSONCredentialMetadata
 }
 
-// DIDBindingMethods returns a list of all the
+// DIDBindingMethods returns a list of all the did methods supported from the list of CryptographicBindingMethodsSupported.
 func (s CredentialSupported) DIDBindingMethods() []did.Method {
 	methods := make([]did.Method, 0, len(s.CryptographicBindingMethodsSupported))
 	for _, bm := range s.CryptographicBindingMethodsSupported {

--- a/oidc/issuance/metadata.go
+++ b/oidc/issuance/metadata.go
@@ -1,0 +1,167 @@
+package issuance
+
+import (
+	"github.com/TBD54566975/ssi-sdk/util"
+	"github.com/goccy/go-json"
+	"github.com/pkg/errors"
+	"golang.org/x/text/language"
+)
+
+type CryptographicBindingMethodSupported string
+
+const (
+	JWKFormat CryptographicBindingMethodSupported = "jwk"
+	COSEKey                                       = "cose_key"
+	AllDIDs                                       = "did"
+)
+
+type Logo struct {
+	Url     *util.URL `json:"url,omitempty"`
+	AltText *string   `json:"alt_text,omitempty"`
+}
+
+type CredentialDisplay struct {
+	displayJSON
+
+	Logo            *Logo   `json:"logo,omitempty"`
+	Description     *string `json:"description,omitempty"`
+	BackgroundColor *string `json:"background_color,omitempty"`
+	TextColor       *string `json:"text_color,omitempty"`
+}
+
+type Format string
+
+const (
+	JwtVcJson   Format = "jwt_vc_json"
+	JwtVcJsonLd        = "jwt_vc_json-ld"
+	LdpVc              = "ldp_vc"
+)
+
+type CredentialSupported struct {
+	Format Format `json:"format" validate:"required"`
+
+	Id *string `json:"id,omitempty"`
+
+	CryptographicBindingMethodsSupported []CryptographicBindingMethodSupported `json:"cryptographic_binding_methods_supported,omitempty"`
+
+	CryptographicSuitesSupported []string `json:"cryptographic_suites_supported,omitempty"`
+
+	Display []CredentialDisplay `json:"display,omitempty"`
+
+	// Present when format == jwt_vc_json
+	*JWTVCJSONCredentialMetadata
+}
+
+type displayJSON struct {
+	Name *string `json:"name,omitempty"`
+
+	Locale *language.Tag `json:"locale,omitempty"`
+
+	// TODO: Support arbitrary fields. Look at https://github.com/hyperledger/aries-framework-go/pull/564/files#diff-953974a5ec9fe3293be8ffd004be86b23666847d300650428cb21673e78fa140
+}
+
+// https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata-p
+type IssuerMetadata struct {
+	CredentialIssuer util.URL `json:"credential_issuer" validate:"required"`
+
+	// Points to a URL that resolves to authorization server metdata as defined in
+	// https://www.rfc-editor.org/rfc/rfc8414.html#section-2
+	AuthorizationServer *util.URL `json:"authorization_server,omitempty"`
+
+	// Must use the `https` scheme.
+	CredentialEndpoint util.URL `json:"credential_endpoint" validate:"required"`
+
+	// Must use the `https` scheme.
+	BatchCredentialEndpoint *util.URL `json:"batch_credential_endpoint,omitempty"`
+
+	CredentialsSupported []CredentialSupported `json:"credentials_supported,omitempty"`
+
+	Display []displayJSON `json:"display,omitempty"`
+}
+
+func (i IssuerMetadata) IsValid() error {
+	if i.CredentialEndpoint.Scheme != "https" {
+		return errors.Errorf("scheme for credential_endpoint must be https (found %s)", i.CredentialEndpoint.Scheme)
+	}
+
+	if i.BatchCredentialEndpoint != nil && i.BatchCredentialEndpoint.Scheme != "https" {
+		return errors.Errorf("scheme for batch_credential_endpoint must be https (found %s)", i.BatchCredentialEndpoint.Scheme)
+	}
+
+	return nil
+}
+
+type Display struct {
+	Name  *string
+	Extra map[string]any
+}
+
+type claimJSON struct {
+	Mandatory *bool   `json:"mandatory,omitempty"`
+	ValueType *string `json:"value_type,omitempty"`
+
+	Display []displayJSON `json:"display,omitempty"`
+}
+
+type Claim struct {
+	Mandatory *bool
+	ValueType *string
+
+	Display       map[language.Tag]Display
+	OtherDisplays []Display
+}
+
+func (c Claim) MarshalJSON() ([]byte, error) {
+	jsonStruct := claimJSON{
+		Mandatory: c.Mandatory,
+		ValueType: c.ValueType,
+		Display:   make([]displayJSON, 0, len(c.Display)+len(c.OtherDisplays)),
+	}
+	for k, v := range c.Display {
+		jsonStruct.Display = append(jsonStruct.Display, displayJSON{
+			Name:   v.Name,
+			Locale: &k,
+		})
+	}
+	for _, v := range c.OtherDisplays {
+		jsonStruct.Display = append(jsonStruct.Display, displayJSON{
+			Name: v.Name,
+		})
+	}
+
+	return json.Marshal(jsonStruct)
+}
+
+func (c *Claim) UnmarshalJSON(data []byte) error {
+	var cJSON claimJSON
+	err := json.Unmarshal(data, &cJSON)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling")
+	}
+	c.Mandatory = cJSON.Mandatory
+	c.ValueType = cJSON.ValueType
+	c.Display = make(map[language.Tag]Display, len(cJSON.Display))
+
+	for _, d := range cJSON.Display {
+		display := Display{
+			Name: d.Name,
+		}
+
+		if d.Locale == nil {
+			c.OtherDisplays = append(c.OtherDisplays, display)
+		} else {
+			if _, ok := c.Display[*d.Locale]; ok {
+				return errors.Errorf("found repeated claim.display.locale for %s", d.Locale)
+			}
+			c.Display[*d.Locale] = display
+		}
+	}
+
+	return nil
+}
+
+type JWTVCJSONCredentialMetadata struct {
+	Types             []string         `json:"types" validate:"required"`
+	CredentialSubject map[string]Claim `json:"credentialSubject,omitempty"`
+	Order             []string         `json:"order,omitempty"`
+}

--- a/oidc/issuance/metadata.go
+++ b/oidc/issuance/metadata.go
@@ -11,12 +11,12 @@ type CryptographicBindingMethodSupported string
 
 const (
 	JWKFormat CryptographicBindingMethodSupported = "jwk"
-	COSEKey                                       = "cose_key"
-	AllDIDs                                       = "did"
+	COSEKey   CryptographicBindingMethodSupported = "cose_key"
+	AllDIDs   CryptographicBindingMethodSupported = "did"
 )
 
 type Logo struct {
-	Url     *util.URL `json:"url,omitempty"`
+	URL     *util.URL `json:"url,omitempty"`
 	AltText *string   `json:"alt_text,omitempty"`
 }
 
@@ -32,9 +32,9 @@ type CredentialDisplay struct {
 type Format string
 
 const (
-	JwtVcJson   Format = "jwt_vc_json"
-	JwtVcJsonLd        = "jwt_vc_json-ld"
-	LdpVc              = "ldp_vc"
+	JwtVcJSON   Format = "jwt_vc_json"
+	JwtVcJSONLd Format = "jwt_vc_json-ld"
+	LdpVc       Format = "ldp_vc"
 )
 
 type CredentialSupported struct {

--- a/oidc/issuance/metadata_test.go
+++ b/oidc/issuance/metadata_test.go
@@ -1,0 +1,39 @@
+package issuance
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed example_issuer_metadata.json
+var exampleIssuerMetadata []byte
+
+func TestUnmarshalAndMarshallIsLossless(t *testing.T) {
+	var m IssuerMetadata
+	require.NoError(t, json.Unmarshal(exampleIssuerMetadata, &m))
+
+	jsonData, err := json.Marshal(m)
+	require.NoError(t, err)
+	require.JSONEq(t, string(exampleIssuerMetadata), string(jsonData))
+}
+
+func TestInvalidJSON(t *testing.T) {
+	claimWithManyLocales := []byte(`{
+	  "display": [
+		{
+		  "name": "Given Name",
+		  "locale": "en-US"
+		},
+		{
+		  "name": "Given Name 2",
+		  "locale": "en-US"
+		}
+	  ]
+	}`)
+	err := json.Unmarshal(claimWithManyLocales, &Claim{})
+	require.Error(t, err)
+	require.Equal(t, "found repeated claim.display.locale for en-US", err.Error())
+}

--- a/oidc/issuance/metadata_test.go
+++ b/oidc/issuance/metadata_test.go
@@ -4,7 +4,9 @@ import (
 	_ "embed"
 	"testing"
 
+	"github.com/TBD54566975/ssi-sdk/did"
 	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +38,19 @@ func TestInvalidJSON(t *testing.T) {
 	err := json.Unmarshal(claimWithManyLocales, &Claim{})
 	require.Error(t, err)
 	require.Equal(t, "found repeated claim.display.locale for en-US", err.Error())
+}
+
+func TestDIDBindingMethods(t *testing.T) {
+	var c CredentialSupported
+	credentialSupportedJSON := []byte(`{
+      "cryptographic_binding_methods_supported": [
+        "did:web",
+        "did:ion",
+        "did",
+        "jwk"
+      ]
+    }`)
+	require.NoError(t, json.Unmarshal(credentialSupportedJSON, &c))
+
+	assert.ElementsMatch(t, []did.Method{"web", "ion"}, c.DIDBindingMethods())
 }

--- a/oidc/issuance/metadata_test.go
+++ b/oidc/issuance/metadata_test.go
@@ -34,7 +34,7 @@ func TestInvalidJSON(t *testing.T) {
 		  "locale": "en-US"
 		}
 	  ]
-	}`)Mo
+	}`)
 	err := json.Unmarshal(claimWithManyLocales, &Claim{})
 	require.Error(t, err)
 	require.Equal(t, "found repeated claim.display.locale for en-US", err.Error())

--- a/oidc/issuance/metadata_test.go
+++ b/oidc/issuance/metadata_test.go
@@ -34,7 +34,7 @@ func TestInvalidJSON(t *testing.T) {
 		  "locale": "en-US"
 		}
 	  ]
-	}`)
+	}`)Mo
 	err := json.Unmarshal(claimWithManyLocales, &Claim{})
 	require.Error(t, err)
 	require.Equal(t, "found repeated claim.display.locale for en-US", err.Error())
@@ -52,5 +52,5 @@ func TestDIDBindingMethods(t *testing.T) {
     }`)
 	require.NoError(t, json.Unmarshal(credentialSupportedJSON, &c))
 
-	assert.ElementsMatch(t, []did.Method{"web", "ion"}, c.DIDBindingMethods())
+	assert.ElementsMatch(t, []did.Method{"web", "ion"}, c.BindingDIDMethods())
 }

--- a/oidc/issuance/metadata_test.go
+++ b/oidc/issuance/metadata_test.go
@@ -22,7 +22,7 @@ func TestUnmarshalAndMarshallIsLossless(t *testing.T) {
 	require.JSONEq(t, string(exampleIssuerMetadata), string(jsonData))
 }
 
-func TestInvalidJSON(t *testing.T) {
+func TestInvalidClaimJSON(t *testing.T) {
 	claimWithManyLocales := []byte(`{
 	  "display": [
 		{
@@ -35,9 +35,28 @@ func TestInvalidJSON(t *testing.T) {
 		}
 	  ]
 	}`)
+
 	err := json.Unmarshal(claimWithManyLocales, &Claim{})
+
 	require.Error(t, err)
 	require.Equal(t, "found repeated claim.display.locale for en-US", err.Error())
+}
+
+func TestInvalidIssuerMetadataJSON(t *testing.T) {
+	metadataWithManyCredentialSupportedIDs := []byte(`{
+		"credentials_supported": [{
+				"id":"one"
+			},
+			{
+				"id":"one"
+			}
+		]
+	}`)
+
+	err := json.Unmarshal(metadataWithManyCredentialSupportedIDs, &IssuerMetadata{})
+
+	require.Error(t, err)
+	require.Equal(t, "found repeated credentials_supported.id for one", err.Error())
 }
 
 func TestDIDBindingMethods(t *testing.T) {

--- a/util/url.go
+++ b/util/url.go
@@ -18,8 +18,8 @@ func (u URL) MarshalJSON() ([]byte, error) {
 
 func (u *URL) UnmarshalJSON(data []byte) error {
 	var dataStr string
-	err := json.Unmarshal(data, &dataStr)
-	if err != nil {
+
+	if err := json.Unmarshal(data, &dataStr); err != nil {
 		return errors.Wrap(err, "unmarshalling")
 	}
 	parsed, err := url.Parse(dataStr)

--- a/util/url.go
+++ b/util/url.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"net/url"
+
+	"github.com/goccy/go-json"
+	"github.com/pkg/errors"
+)
+
+// URL is a wrapper struct of url.URL in order to unmarshal(marshal) URLs from(to) strings.
+type URL struct {
+	url.URL
+}
+
+func (u URL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.URL.String())
+}
+
+func (u *URL) UnmarshalJSON(data []byte) error {
+	var dataStr string
+	err := json.Unmarshal(data, &dataStr)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling")
+	}
+	parsed, err := url.Parse(dataStr)
+	if err != nil {
+		return errors.Wrap(err, "parsing url")
+	}
+	u.URL = *parsed
+	return nil
+}

--- a/util/url_test.go
+++ b/util/url_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestURL_MarshalJSON(t *testing.T) {
+	u := URL{url.URL{Scheme: "https", Host: "example.com"}}
+
+	got, err := u.MarshalJSON()
+
+	expected := []byte(`"https://example.com"`)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, got)
+}
+
+func TestURL_UnmarshalJSON(t *testing.T) {
+	data := []byte(`"web5://tbd.website"`)
+	var u URL
+
+	assert.NoError(t, u.UnmarshalJSON(data))
+
+	expected := URL{url.URL{Scheme: "web5", Host: "tbd.website"}}
+	assert.Equal(t, expected, u)
+
+}

--- a/util/url_test.go
+++ b/util/url_test.go
@@ -25,5 +25,4 @@ func TestURL_UnmarshalJSON(t *testing.T) {
 
 	expected := URL{url.URL{Scheme: "web5", Host: "tbd.website"}}
 	assert.Equal(t, expected, u)
-
 }


### PR DESCRIPTION
This is based in the spec section https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata

I believe the SDK is the best home for this. My expectation is that other folks will need to support this kind of models, and providing a library to do so easily will be beneficial to the community. 

I thought about separating it into it's own module, but given that we're packaging all functionality into the SDK, I believe this is the best place for this to live. 