### PR TITLE
Add JWT header extraction; fix errs

### DIFF
--- a/credential/exchange/request.go
+++ b/credential/exchange/request.go
@@ -106,7 +106,7 @@ func VerifyPresentationRequest(verifier crypto.JWTVerifier, pt PresentationReque
 // VerifyJWTPresentationRequest verifies the signature on a JWT-based presentation request for a given verifier
 // and then returns the parsed Presentation Definition object as a result.
 func VerifyJWTPresentationRequest(verifier crypto.JWTVerifier, request []byte) (*PresentationDefinition, error) {
-	parsed, err := verifier.VerifyAndParse(string(request))
+	_, parsed, err := verifier.VerifyAndParse(string(request))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not verify and parse jwt presentation request")
 	}

--- a/credential/exchange/request_test.go
+++ b/credential/exchange/request_test.go
@@ -24,12 +24,16 @@ func TestBuildPresentationRequest(t *testing.T) {
 		verifier, err := signer.ToVerifier()
 		assert.NoError(t, err)
 
-		parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
+		headers, parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
 		assert.NoError(t, err)
 
 		presDef, ok := parsed.Get(PresentationDefinitionKey)
 		assert.True(t, ok)
 		jsonEq(t, testDef, presDef)
+
+		kid, ok := headers.Get("kid")
+		assert.True(t, ok)
+		assert.Equal(t, "test-kid", kid)
 	})
 
 	t.Run("Happy Path", func(t *testing.T) {
@@ -47,12 +51,16 @@ func TestBuildPresentationRequest(t *testing.T) {
 		verifier, err := signer.ToVerifier()
 		assert.NoError(t, err)
 
-		parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
+		headers, parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
 		assert.NoError(t, err)
 
 		presDef, ok := parsed.Get(PresentationDefinitionKey)
 		assert.True(t, ok)
 		jsonEq(t, testDef, presDef)
+
+		kid, ok := headers.Get("kid")
+		assert.True(t, ok)
+		assert.Equal(t, "test-kid", kid)
 	})
 
 	t.Run("Unsupported Request Method", func(t *testing.T) {

--- a/credential/exchange/submission_test.go
+++ b/credential/exchange/submission_test.go
@@ -54,7 +54,7 @@ func TestBuildPresentationSubmission(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, submissionBytes)
 
-		_, vp, err := signing.VerifyVerifiablePresentationJWT(*verifier, string(submissionBytes))
+		_, _, vp, err := signing.VerifyVerifiablePresentationJWT(*verifier, string(submissionBytes))
 		assert.NoError(tt, err)
 
 		assert.NoError(tt, vp.IsValid())

--- a/credential/exchange/verification.go
+++ b/credential/exchange/verification.go
@@ -29,7 +29,7 @@ func VerifyPresentationSubmission(verifier crypto.JWTVerifier, et EmbedTarget, d
 	}
 	switch et {
 	case JWTVPTarget:
-		_, vp, err := signing.VerifyVerifiablePresentationJWT(verifier, string(submission))
+		_, _, vp, err := signing.VerifyVerifiablePresentationJWT(verifier, string(submission))
 		if err != nil {
 			return errors.Wrap(err, "verification of the presentation submission failed")
 		}

--- a/credential/exchange/verification_test.go
+++ b/credential/exchange/verification_test.go
@@ -111,7 +111,7 @@ func TestVerifyPresentationSubmissionVP(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, submissionBytes)
 
-		_, verifiablePresentation, err := signing.ParseVerifiablePresentationFromJWT(string(submissionBytes))
+		_, _, verifiablePresentation, err := signing.ParseVerifiablePresentationFromJWT(string(submissionBytes))
 		assert.NoError(tt, err)
 
 		err = VerifyPresentationSubmissionVP(def, *verifiablePresentation)

--- a/credential/signing/jws.go
+++ b/credential/signing/jws.go
@@ -50,7 +50,7 @@ func ParseVerifiableCredentialFromJWS(token string) (*jws.Message, *credential.V
 		}
 	}
 	if signature == nil {
-		_, cred, err := ParseVerifiableCredentialFromJWT(token)
+		_, _, cred, err := ParseVerifiableCredentialFromJWT(token)
 		return parsed, cred, err
 	}
 

--- a/credential/signing/jwt_test.go
+++ b/credential/signing/jwt_test.go
@@ -32,16 +32,20 @@ func TestVerifiableCredentialJWT(t *testing.T) {
 		err = verifier.Verify(token)
 		assert.NoError(t, err)
 
-		parsedJWT, parsedCred, err := ParseVerifiableCredentialFromJWT(token)
+		parsedHeaders, parsedJWT, parsedCred, err := ParseVerifiableCredentialFromJWT(token)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, parsedJWT)
 		assert.NotEmpty(t, parsedCred)
+		assert.NotEmpty(t, parsedHeaders)
 
-		verifiedJWT, cred, err := VerifyVerifiableCredentialJWT(*verifier, token)
+		headers, verifiedJWT, cred, err := VerifyVerifiableCredentialJWT(*verifier, token)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, verifiedJWT)
+		assert.NotEmpty(t, cred)
+		assert.NotEmpty(t, headers)
 		assert.Equal(t, parsedJWT, verifiedJWT)
 		assert.Equal(t, parsedCred, cred)
+		assert.Equal(t, parsedHeaders, headers)
 	})
 
 	t.Run("Generated Private Key For Signer", func(tt *testing.T) {
@@ -61,16 +65,18 @@ func TestVerifiableCredentialJWT(t *testing.T) {
 		err = verifier.Verify(token)
 		assert.NoError(tt, err)
 
-		parsedJWT, parsedCred, err := ParseVerifiableCredentialFromJWT(token)
+		parsedHeaders, parsedJWT, parsedCred, err := ParseVerifiableCredentialFromJWT(token)
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, parsedJWT)
+		assert.NotEmpty(tt, parsedHeaders)
 		assert.NotEmpty(tt, parsedCred)
 
-		verifiedJWT, cred, err := VerifyVerifiableCredentialJWT(*verifier, token)
+		verifiedHeaders, verifiedJWT, cred, err := VerifyVerifiableCredentialJWT(*verifier, token)
 		assert.NoError(tt, err)
 		assert.NotEmpty(tt, verifiedJWT)
 		assert.Equal(tt, parsedJWT, verifiedJWT)
 		assert.Equal(tt, parsedCred, cred)
+		assert.Equal(tt, parsedHeaders, verifiedHeaders)
 	})
 }
 
@@ -93,14 +99,17 @@ func TestVerifiablePresentationJWT(t *testing.T) {
 	err = verifier.Verify(token)
 	assert.NoError(t, err)
 
-	parsedJWT, parsedPres, err := ParseVerifiablePresentationFromJWT(token)
+	parsedHeaders, parsedJWT, parsedPres, err := ParseVerifiablePresentationFromJWT(token)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, parsedJWT)
+	assert.NotEmpty(t, parsedHeaders)
 	assert.NotEmpty(t, parsedPres)
 
-	verifiedJWT, pres, err := VerifyVerifiablePresentationJWT(*verifier, token)
+	parsedHeaders, verifiedJWT, pres, err := VerifyVerifiablePresentationJWT(*verifier, token)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, verifiedJWT)
+	assert.NotEmpty(t, parsedHeaders)
+	assert.Equal(t, parsedJWT, verifiedJWT)
 	assert.Equal(t, parsedPres, pres)
 }
 

--- a/credential/util/util.go
+++ b/credential/util/util.go
@@ -15,7 +15,7 @@ func CredentialsFromInterface(genericCred any) (*credential.VerifiableCredential
 	switch genericCred.(type) {
 	case string:
 		// JWT
-		_, cred, err := signing.ParseVerifiableCredentialFromJWT(genericCred.(string))
+		_, _, cred, err := signing.ParseVerifiableCredentialFromJWT(genericCred.(string))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse credential from JWT")
 		}

--- a/crypto/jwt_test.go
+++ b/crypto/jwt_test.go
@@ -127,17 +127,21 @@ func TestSignVerifyGenericJWT(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, token)
 
-	signerParsed, err := signer.Parse(string(token))
+	headers, signerParsed, err := signer.Parse(string(token))
 	assert.NoError(t, err)
 
 	gotSignerID, ok := signerParsed.Get("id")
 	assert.True(t, ok)
 	assert.EqualValues(t, "abcd", gotSignerID)
 
+	gotKID, ok := headers.Get("kid")
+	assert.True(t, ok)
+	assert.EqualValues(t, "did:example:123#key-0", gotKID)
+
 	err = verifier.Verify(string(token))
 	assert.NoError(t, err)
 
-	parsed, err := verifier.Parse(string(token))
+	headers, parsed, err := verifier.Parse(string(token))
 	assert.NoError(t, err)
 
 	gotID, ok := parsed.Get("id")
@@ -152,7 +156,11 @@ func TestSignVerifyGenericJWT(t *testing.T) {
 	assert.True(t, ok)
 	assert.EqualValues(t, []any{"one", "two", "three"}, gotData)
 
-	_, err = verifier.VerifyAndParse(string(token))
+	kid, ok := headers.Get("kid")
+	assert.True(t, ok)
+	assert.EqualValues(t, "did:example:123#key-0", kid)
+
+	_, _, err = verifier.VerifyAndParse(string(token))
 	assert.NoError(t, err)
 
 	// parse out the headers

--- a/example/presentation/presentation.go
+++ b/example/presentation/presentation.go
@@ -44,8 +44,7 @@ func makePresentationData() exchange.PresentationDefinition {
 }
 
 // Build a presentation request (PR)
-// A PR is sent by a verifier to a holder
-// It can be sent over multiple mechanisms
+// A PR is sent by a verifier to a holder. It can be sent via multiple mechanisms
 // For more information, please go to here:
 // https://identity.foundation/presentation-exchange/#presentation-request
 // and for the source code with the sdk,
@@ -84,7 +83,7 @@ func makePresentationRequest(requesterID string, presentationData exchange.Prese
 		return nil, err
 	}
 
-	parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
+	_, parsed, err := verifier.VerifyAndParse(string(requestJWTBytes))
 	if err != nil {
 		return nil, err
 	}

--- a/example/usecase/apartment_application/apartment_application.go
+++ b/example/usecase/apartment_application/apartment_application.go
@@ -138,7 +138,7 @@ func main() {
 
 	// TODO: (neal) (issue https://github.com/TBD54566975/ssi-sdk/issues/165)
 	// Have the presentation claim's token format support signedVCBytes for the BuildPresentationSubmission function
-	_, vsJSON, err := signing.ParseVerifiableCredentialFromJWT(string(signedVCBytes))
+	_, _, vsJSON, err := signing.ParseVerifiableCredentialFromJWT(string(signedVCBytes))
 	example.HandleExampleError(err, "Failed to parse VC")
 	vcJSONBytes, err := json.Marshal(vsJSON)
 	example.HandleExampleError(err, "Failed to marshal vc jwt")

--- a/example/usecase/employer_university_flow/main.go
+++ b/example/usecase/employer_university_flow/main.go
@@ -162,7 +162,7 @@ func main() {
 
 	verifier, err := signer.ToVerifier()
 	example.HandleExampleError(err, "failed to construct verifier")
-	_, vp, err := signing.VerifyVerifiablePresentationJWT(*verifier, string(submission))
+	_, _, vp, err := signing.VerifyVerifiablePresentationJWT(*verifier, string(submission))
 	example.HandleExampleError(err, "failed to verify jwt")
 
 	dat, err = json.Marshal(vp)

--- a/example/usecase/employer_university_flow/pkg/util.go
+++ b/example/usecase/employer_university_flow/pkg/util.go
@@ -68,7 +68,7 @@ func BuildPresentationSubmission(presentationRequestJWT string, signer crypto.JW
 	if err != nil {
 		return nil, errors.Wrap(err, "creating verifier from signer")
 	}
-	parsedPresentationRequest, err := verifier.VerifyAndParse(presentationRequestJWT)
+	_, parsedPresentationRequest, err := verifier.VerifyAndParse(presentationRequestJWT)
 	if err != nil {
 		return nil, err
 	}

--- a/example/usecase/employer_university_flow/pkg/verifier.go
+++ b/example/usecase/employer_university_flow/pkg/verifier.go
@@ -14,7 +14,7 @@ import (
 // 1. That the VC is valid
 // 2. That the VC was issued by a trusted entity
 func ValidateAccess(verifier crypto.JWTVerifier, credBytes []byte) error {
-	_, vp, err := signing.VerifyVerifiablePresentationJWT(verifier, string(credBytes))
+	_, _, vp, err := signing.VerifyVerifiablePresentationJWT(verifier, string(credBytes))
 	if err != nil {
 		return errors.Wrap(err, "failed to validate VP signature")
 	}

--- a/util/errors.go
+++ b/util/errors.go
@@ -38,6 +38,9 @@ func LoggingNewErrorf(msg string, args ...any) error {
 // LoggingErrorMsg is a utility to combine logging an error, and returning and error with a message
 func LoggingErrorMsg(err error, msg string) error {
 	logrus.WithError(err).Error(SanitizeLog(msg))
+	if err == nil {
+		return errors.New(msg)
+	}
 	return errors.Wrap(err, msg)
 }
 


### PR DESCRIPTION
- support extracting headers from JWTs, useful for getting `kid` and other info needed in verification
- for a logging err, check if err is nil, which was resulting in returning a nil value when an error was expected