### PR TITLE
Fix resolution metadata validation with datetime

### DIFF
--- a/did/resolution/model.go
+++ b/did/resolution/model.go
@@ -24,8 +24,8 @@ func (r *ResolutionResult) IsEmpty() bool {
 
 // DocumentMetadata https://www.w3.org/TR/did-core/#did-document-metadata
 type DocumentMetadata struct {
-	Created       string `json:"created,omitempty" validate:"datetime"`
-	Updated       string `json:"updated,omitempty" validate:"datetime"`
+	Created       string `json:"created,omitempty"`
+	Updated       string `json:"updated,omitempty"`
 	Deactivated   bool   `json:"deactivated,omitempty"`
 	NextUpdate    string `json:"nextUpdate,omitempty"`
 	VersionID     string `json:"versionId,omitempty"`
@@ -35,6 +35,12 @@ type DocumentMetadata struct {
 }
 
 func (s *DocumentMetadata) IsValid() bool {
+	if s.Created != "" && !util.IsRFC3339Timestamp(s.Created) {
+		return false
+	}
+	if s.Updated != "" && !util.IsRFC3339Timestamp(s.Updated) {
+		return false
+	}
 	return util.NewValidator().Struct(s) == nil
 }
 

--- a/did/resolution/model.go
+++ b/did/resolution/model.go
@@ -24,8 +24,8 @@ func (r *ResolutionResult) IsEmpty() bool {
 
 // DocumentMetadata https://www.w3.org/TR/did-core/#did-document-metadata
 type DocumentMetadata struct {
-	Created       string `json:"created,omitempty"`
-	Updated       string `json:"updated,omitempty"`
+	Created       string `json:"created,omitempty" validate:"omitempty,datetime=2006-01-02T15:04:05Z"`
+	Updated       string `json:"updated,omitempty" validate:"omitempty,datetime=2006-01-02T15:04:05Z"`
 	Deactivated   bool   `json:"deactivated,omitempty"`
 	NextUpdate    string `json:"nextUpdate,omitempty"`
 	VersionID     string `json:"versionId,omitempty"`
@@ -35,12 +35,6 @@ type DocumentMetadata struct {
 }
 
 func (s *DocumentMetadata) IsValid() bool {
-	if s.Created != "" && !util.IsRFC3339Timestamp(s.Created) {
-		return false
-	}
-	if s.Updated != "" && !util.IsRFC3339Timestamp(s.Updated) {
-		return false
-	}
 	return util.NewValidator().Struct(s) == nil
 }
 

--- a/did/resolution/resolver_test.go
+++ b/did/resolution/resolver_test.go
@@ -12,6 +12,15 @@ func TestDIDDocumentMetadata_IsValid(t *testing.T) {
 		var metadata DocumentMetadata
 		assert.True(t, metadata.IsValid())
 	})
+
+	t.Run("test valid time", func(t *testing.T) {
+		now := time.Now().UTC().Format(time.RFC3339)
+		var metadata = DocumentMetadata{
+			Created: now,
+		}
+		assert.True(t, metadata.IsValid())
+	})
+
 	t.Run("returns false when created field is not a timestamp", func(t *testing.T) {
 		badMetadata := DocumentMetadata{
 			Created: "bad",


### PR DESCRIPTION
The resolution validation code was failing due to the following: 

If you go to validator.v10 docs:

https://github.com/go-playground/validator/blob/c8b98cbcea08971fbead222ddf5fd406a40d40ed/validator_test.go#L12041

You will see that it requires to specify format of datetime string, otherwise, this test will fail: 

```go
t.Run("test valid time", func(t *testing.T) {
    now := time.Now().UTC().Format(time.RFC3339)
    var metadata = DocumentMetadata{
	Created: now,
    }
    assert.True(t, metadata.IsValid())
})
```

with the datetime validation failing. I have added a test to validate that the created field can properly be validate against the resolution metdata, and that the datetime field for validator is compared against RFC3339 specification (see below) 