### PR TITLE
Fix typo in Quick Start command in README.md

### DIFF
--- a/sd-jwt/README.md
+++ b/sd-jwt/README.md
@@ -35,7 +35,7 @@ See the terminal command below.
 ```shell
 git clone github.com/TBD54566975/ssi-sdk.git
 cd ssi-sdk/sd-jwt
-go run example.main.go
+go run example/main.go
 ```
 
 ## Usage


### PR DESCRIPTION
I was going through the README.md of sd-jwt and noticed a small typo that I believe needs correction. Here are the details:
```
$ go run example.main.go
stat example.main.go: no such file or directory

$ go run example/main.go
Combined Issuance Format
eyJhbGciOiJFUzI1NiIsInR5cCI6Ikp...
```